### PR TITLE
No Automatic Bitrate Changing Fix (Issue #21)

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestStream.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestStream.as
@@ -51,7 +51,7 @@ package com.kaltura.hls.manifest
 							newNote.programId = parseInt(accum);
 							break;
 						case "BANDWIDTH":
-							// We devide this value by 1000 to convert into Kilobits
+							// We divide this value by 1000 to convert into Kilobits
 							newNote.bandwidth = parseInt(accum) / 1000;
 							break;
 						case "CODECS":


### PR DESCRIPTION
Added some simple code converting data related to bandwidth from bits to
kilobits because OSMF works in kilobits. This now enables automatic
bitrate changing to occur normally.

It's 7 characters including 2 spaces as well as a comment.
