### PR TITLE
Single Livestream Start Time Fix

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSLoader.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSLoader.as
@@ -124,6 +124,9 @@ package com.kaltura.hls
 			{
 				item = new DynamicStreamingItem(URLResource(loadTrait.resource).url, 0, 0, 0);
 				items.push(item);
+				
+				// Also set the DVR state
+				if ( !stream.manifest.streamEnds ) isDVR = true;
 			}
 			
 			var alternateAudioItems:Vector.<StreamingItem> = new <StreamingItem>[];


### PR DESCRIPTION
Bug Fixes:
- Fixed an issue causing livestreams to start at the beginning of the DVR
  window when the primary manifest is also the only stream manifest.

This should address issue #44 
