### PR TITLE
Unnecessary Remapping Fix

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
@@ -527,7 +527,7 @@ package com.kaltura.hls
 				return -1;
 			}
 
-			if(currentManifest == newManifest)
+			if(currentManifest.fullUrl == newManifest.fullUrl)
 			{
 				return currentSequence;
 			}


### PR DESCRIPTION
- Fixed an issue that would cause unnecessary segment index remapping,
  resulting in repeating/skipped segments on some streams
