### PR TITLE
Improved logic for guessing timebase segments.

### DIFF
--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
@@ -352,16 +352,22 @@ package org.osmf.net.httpstreaming
 				{
 					var lastMan:HLSManifestParser = indexHandler.getLastSequenceManifest();
 					if(lastMan && lastMan.targetDuration > 0.0)
+					{
 						value = HLSManifestParser.MAX_SEG_BUFFER * lastMan.targetDuration * 0.9;
+					}
 				}
 
 				// skip nop.
 				if(Math.abs(super.bufferTime - value) < 0.01)
-					return;				
+					return;
+
+				if(lastMan && lastMan.targetDuration > 0.0)
+					trace(" bufferTime " + value + " based on " + HLSManifestParser.MAX_SEG_BUFFER + " * " + lastMan.targetDuration + " * 0.9");
+				else
+					trace(" bufferTime " + value + " based on " + HLSManifestParser.MAX_SEG_BUFFER + " * 7.5");
 			}
 
-			trace("Trying to set buffertime to " + value + ", ignoring...");
-
+			trace("Trying to set buffertime to " + value);
 			super.bufferTime = value;
 			trace("   o super.bufferTime = " + super.bufferTime);
 			_desiredBufferTime_Min = Math.max(OSMFSettings.hdsMinimumBufferTime, value);

--- a/TestPlayer/src/TestPlayer.mxml
+++ b/TestPlayer/src/TestPlayer.mxml
@@ -174,7 +174,7 @@
 				traceWindow.addEventListener(CloseEvent.CLOSE, onTraceClose); */
 				
 				// Adjust the segment buffer length by altering this static variable
-				HLSManifestParser.MAX_SEG_BUFFER = 4;
+				HLSManifestParser.MAX_SEG_BUFFER = 3;
 				
 				loadVariableURL();
 			}


### PR DESCRIPTION
Hi Einat!

If you have a chance, please try this change (but note that I have not fully tested it so send it to QA at your own risk). It was all I had time for starting at 11pm tonight. :)

This improves the timebase segment fetching but it sometimes makes wrong choices due to having outdated manifests on live streams. It improves stream startup times but there is still a ~20% win on the table.

Monday, I will make the manifest reload logic smarter (it can tell due to HLS spec exactly when a manifest is out of date and must be refreshed). I can also make the default live edge be another segment back from the buffer (so we would buffer MAX_SEG_BUFFERS and then back off but not buffer one more segment). Between these two fixes, all of the test streams should do their initial upshifts without making a wrong guess.

Note that the guessing logic ONLY gives a win on streams where sequence IDs have corresponding times or nearly so. If you seek to a stream where IDs don't match up it will take as long as before. I will compare to Safari to see if it can somehow do better in that case, but I don't believe it can.

I can also make it more aggressive about closing timebase fetches that are wrong before they are fully downloaded. This will improve things more.

I am glad we are now identifying issues where things are correct but can be faster. It indicates the HLS OSMF plugin is stabilizing.

Thanks,
Ben
