### PR TITLE
Debugging Aids.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -156,11 +156,13 @@ package com.kaltura.hls.m2ts
 			_segmentLastSeconds = -1;
 			_lastInjectedSubtitleTime = -1;
 			_encryptedDataBuffer.length = 0;
+
+			// Note the start as a debug event.
+			_parser.sendDebugEvent( {type:"segmentStart", uri:segmentUri});
 		}
 		
 		public override function get inputBytesNeeded():Number
 		{
-			// Get TS packets!
 			return 0;
 		}
 
@@ -298,6 +300,9 @@ package com.kaltura.hls.m2ts
 			if ( key && !key.isLoaded ) trace("HIT END OF FILE WITH NO KEY!");
 
 			if ( key ) key.usePadding = true;
+
+			// Note the start as a debug event.
+			_parser.sendDebugEvent( {type:"segmentEnd", uri:segmentUri});
 			
 			var rv:ByteArray = basicProcessFileSegment(input, true);
 			

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
@@ -251,6 +251,14 @@ package com.kaltura.hls.m2ts
         }
 
         /**
+         * Fire off a debug event.
+         */
+        public function sendDebugEvent( data:Object):void
+        {
+            pesProcessor.transcoder.sendDebugEvent(data);
+        }
+
+        /**
          * Allocate or retrieve the packet stream state for a given packet ID.
          */
         protected function getPacketStream(pid:int):TSPacketStream

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
@@ -61,6 +61,12 @@ package org.osmf.net.httpstreaming
 	 */ 
 	public class HLSHTTPStreamSource implements IHTTPStreamSource, IHTTPStreamHandler
 	{
+		// Listen to this to receive HTTPStreamingEvents related to segment start/end.
+		//
+		// Note this occurs in realtime as the segments are downloaded - not as they are played,
+		// which may happen much later.
+		public static var debugBus:EventDispatcher = new EventDispatcher();
+
 		/**
 		 * Default constructor.
 		 */
@@ -555,6 +561,18 @@ package org.osmf.net.httpstreaming
 						)
 					);
 
+					debugBus.dispatchEvent( 
+						new HTTPStreamingEvent(
+							HTTPStreamingEvent.BEGIN_FRAGMENT, 
+							false,
+							true,
+							NaN,
+							null,
+							null,
+							_streamName
+						)
+					);
+
 					setState(HTTPStreamingState.READ);
 					break;
 				
@@ -628,6 +646,18 @@ package org.osmf.net.httpstreaming
 					
 					
 					_dispatcher.dispatchEvent( 
+						new HTTPStreamingEvent(
+							HTTPStreamingEvent.END_FRAGMENT,
+							false,
+							true,
+							NaN,
+							null,
+							null,
+							_streamName
+						)
+					);
+
+					debugBus.dispatchEvent( 
 						new HTTPStreamingEvent(
 							HTTPStreamingEvent.END_FRAGMENT,
 							false,


### PR DESCRIPTION
Listen for HTTPStreamingEvent BEGIN_FRAGMENT and END_FRAGMENT on
HLSHTTPStreamSource.debugBus to see when segments are downloaded.
Listen for hlsDebug events in the FLV stream to see when they are
played.