### PR TITLE
PLAT-2016 - Fixes for stall when switching stitched ads.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
@@ -140,6 +140,7 @@ package com.kaltura.hls
 		// seg if known.  Since all segments are immutable, we can keep this
 		// as a global cache.
 		public static var startTimeWitnesses:Object = {};
+		public static var endTimeWitnesses:Object = {};
 
 
 		CONFIG::LOGGING
@@ -161,11 +162,10 @@ package com.kaltura.hls
 		}
 
 
+		// Using our witnesses, fill in as much knowledge as we can about 
+		// segment start/end times.
 		public function updateSegmentTimes(segments:Vector.<HLSManifestSegment>):Vector.<HLSManifestSegment>
 		{
-			// Using our witnesses, fill in as much knowledge as we can about 
-			// segment start/end times.
-
 			// Keep track of whatever segments we've assigned to.
 			var setSegments:Object = {};
 
@@ -177,6 +177,7 @@ package com.kaltura.hls
 					continue;
 
 				segments[i].startTime = startTimeWitnesses[segments[i].uri];
+				segments[i].duration = endTimeWitnesses[segments[i].uri] - segments[i].startTime;
 				setSegments[i] = 1;
 			}
 
@@ -287,6 +288,15 @@ package com.kaltura.hls
 			return -1;
 		}
 
+		/** 
+		 * Find the segment from a time-ordered list containing the specified time.
+		 *
+		 * We don't check for exact containment because segments may have slight
+		 * gaps between them. Therefore the user provides a bias flag - when 
+		 * biasing backwards, we look for the first segment which has extents 
+		 * ahead of time, while when biasing forwards we look for first segment
+		 * which has extents behind time.
+		 */ 
 		public static function getSegmentContainingTime(segments:Vector.<HLSManifestSegment>, time:Number, biasBackward:Boolean = false):HLSManifestSegment
 		{
 			if(biasBackward)
@@ -316,7 +326,7 @@ package com.kaltura.hls
 					if(segments[i].startTime > time)
 						return segments[i-1];
 					
-					// The first index is a special case
+					// The last index (first checked) is a special case
 					if (i == segments.length && segments[i].startTime + segments[i].duration < time)
 						return segments[i];
 				}				
@@ -1153,7 +1163,9 @@ package com.kaltura.hls
 				return new HTTPStreamRequest(HTTPStreamRequestKind.LIVE_STALL, null, 2);
 			}
 
-			// Advance sequence number if we didn't seed.
+			// Advance sequence number if we didn't seed. This prevensts us from
+			// inadvertantly advancing past the first segment of a video in streams 
+			// with non-zero start times.
 			if(!didWeSeedLastSequence)
 				newSequence++;
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -308,6 +308,13 @@ package com.kaltura.hls.m2ts
 			
 			var elapsed:Number = _segmentLastSeconds - _segmentBeginSeconds;
 			
+			// Also update end time - don't trace it as we'll increase it incrementally.
+			if(HLSIndexHandler.endTimeWitnesses[segmentUri] == null)
+			{
+				trace("Noting segment end time for " + segmentUri + " of " + _segmentLastSeconds);
+				HLSIndexHandler.endTimeWitnesses[segmentUri] = _segmentLastSeconds;
+			}
+
 			if(elapsed <= 0.0 && _extendedIndexHandler)
 			{
 				elapsed = _extendedIndexHandler.getTargetSegmentDuration(); // XXX fudge hack!


### PR DESCRIPTION
***Please land #108 first.***

This adds more accurate accounting of time when switching quality levels. Please try this against an ad stitch pause/freeze case and report Vizzy log if it fails.