### PR TITLE
Much better captions support.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSDVRTimeTrait.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSDVRTimeTrait.as
@@ -61,6 +61,11 @@ package com.kaltura.hls
 			return _dvrInfo.curLength;
 		}
 		
+		public function get absoluteTime():Number
+		{
+			return _stream.absoluteTime;
+		}
+
 		override public function get currentTime():Number
 		{
 			return _stream.time;

--- a/HLSPlugin/src/com/kaltura/hls/SubtitleEvent.as
+++ b/HLSPlugin/src/com/kaltura/hls/SubtitleEvent.as
@@ -1,0 +1,25 @@
+package com.kaltura.hls
+{
+	import flash.events.*;
+	
+	/**
+	 * An event describing subtitle text. Fired from the SubtitleTrait.
+	 */
+	public class SubtitleEvent extends Event
+	{
+		public static const CUE:String = "cue";
+		
+		public var startTime:Number;
+		public var text:String;
+		public var language:String;
+
+		public function SubtitleEvent(_startTime:Number, _text:String, _language:String)
+		{
+			super(CUE);
+
+			startTime = _startTime;
+			text = _text;
+			language = _language;
+		}
+	
+}}

--- a/HLSPlugin/src/com/kaltura/hls/SubtitleTrait.as
+++ b/HLSPlugin/src/com/kaltura/hls/SubtitleTrait.as
@@ -95,6 +95,7 @@ package com.kaltura.hls
 		{
 			var subtitles:Vector.<SubTitleParser> = activeSubtitles;
 			var subtitleCount:int = subtitles.length;
+			var potentials:Vector.<TextTrackCue> = new Vector.<TextTrackCue>();
 
 			for ( var i:int = 0; i < subtitleCount; i++ )
 			{
@@ -103,8 +104,6 @@ package com.kaltura.hls
 				if ( subtitle.endTime < startTime ) continue;
 				var cues:Vector.<TextTrackCue> = subtitle.textTrackCues;
 				var cueCount:int = cues.length;
-				
-				var potentials:Vector.<TextTrackCue> = new Vector.<TextTrackCue>();
 
 				for ( var j:int = 0; j < cueCount; j++ )
 				{
@@ -115,20 +114,24 @@ package com.kaltura.hls
 						potentials.push(cue);
 					}
 				}
+			}
 
-				if(potentials.length > 0)
+			if(potentials.length > 0)
+			{
+				// TODO: Add support for trackid
+				cue = potentials[potentials.length - 1];
+				if(cue != _lastCue)
 				{
-					// TODO: Add support for trackid
-					cue = potentials[potentials.length - 1];
-					if(cue != _lastCue)
-					{
-						dispatchEvent(new SubtitleEvent(cue.startTime, cue.text, language));
+					dispatchEvent(new SubtitleEvent(cue.startTime, cue.text, language));
 
-						_lastInjectedSubtitleTime = cue.startTime;
-						_lastCue = cue;						
-					}
+					_lastInjectedSubtitleTime = cue.startTime;
+					_lastCue = cue;						
 				}
 			}
+
+			// Force last time so we eventually show proper subtitles.
+			_lastInjectedSubtitleTime = endTime;
+
 		}
 
 		/**
@@ -244,38 +247,8 @@ package com.kaltura.hls
 		
 		public function set language( value:String ):void
 		{
-			// Trigger a seek to flush buffer and get proper language.
-			if(_language != value)
-			{
-				_language = value;
-
-				trace("Triggering flush for proper subtitle language.");
-				if(owningMediaElement)
-				{
-					var st:SeekTrait = owningMediaElement.getTrait(MediaTraitType.SEEK) as SeekTrait;
-					var tt:TimeTrait = owningMediaElement.getTrait(MediaTraitType.TIME) as TimeTrait;
-					
-					if(st == null)
-					{
-						trace("   o No seek trait, skipping...");
-					}
-
-					if(tt == null)
-					{
-						trace("   o No time trait, skipping...");
-					}
-
-					if(st != null && tt != null)
-					{
-						trace("   o Initiating seek to " + tt.currentTime);
-						//st.seek(tt.currentTime);
-					}
-				}
-				else
-				{
-					trace("   o No media element, skipping...");
-				}
-			}
+			// No special logic required, we will sort it out elsewhere.
+			_language = value;
 		}
 		
 		public function get language():String

--- a/HLSPlugin/src/com/kaltura/hls/SubtitleTrait.as
+++ b/HLSPlugin/src/com/kaltura/hls/SubtitleTrait.as
@@ -80,7 +80,9 @@ package com.kaltura.hls
 			var curTime:Number = tt.currentTime;
 			if(tt is HLSDVRTimeTrait)
 				curTime = (tt as HLSDVRTimeTrait).absoluteTime;
-			trace("onSubtitleTimer - Current time is: " + curTime);
+			
+			// This is quite verbose but useful for debugging.
+			// trace("onSubtitleTimer - Current time is: " + curTime);
 
 			// Now, fire off any subtitles that are new.
 			activeTrait.emitSubtitles(activeTrait._lastInjectedSubtitleTime, curTime);
@@ -97,7 +99,7 @@ package com.kaltura.hls
 			for ( var i:int = 0; i < subtitleCount; i++ )
 			{
 				var subtitle:SubTitleParser = subtitles[ i ];
-				if ( subtitle.startTime > endTime ) break;
+				if ( subtitle.startTime > endTime ) continue;
 				if ( subtitle.endTime < startTime ) continue;
 				var cues:Vector.<TextTrackCue> = subtitle.textTrackCues;
 				var cueCount:int = cues.length;
@@ -120,8 +122,8 @@ package com.kaltura.hls
 					cue = potentials[potentials.length - 1];
 					if(cue != _lastCue)
 					{
-						//_parser.createAndSendCaptionMessage( cue.startTime, cue.text, subtitleTrait.language );
-						trace("SUBTITLE " + cue.text );
+						dispatchEvent(new SubtitleEvent(cue.startTime, cue.text, language));
+
 						_lastInjectedSubtitleTime = cue.startTime;
 						_lastCue = cue;						
 					}

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/FLVTranscoder.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/FLVTranscoder.as
@@ -410,10 +410,10 @@ package com.kaltura.hls.m2ts
             //sendScriptDataFLVTag( timeStamp * 1000, captionObject);
 
             // We need to strip the timestamp off of the text data
-            captionBuffer = captionBuffer.slice(captionBuffer.indexOf('\n') + 1);
+            //captionBuffer = captionBuffer.slice(captionBuffer.indexOf('\n') + 1);
 
-            var subtitleObject:Array = ["onTextData", { text:captionBuffer, language:lang, trackid:textid }];
-            sendScriptDataFLVTag( timeStamp * 1000, subtitleObject);
+            //var subtitleObject:Array = ["onTextData", { text:captionBuffer, language:lang, trackid:textid }];
+            //sendScriptDataFLVTag( timeStamp * 1000, subtitleObject);
         }
 
         protected var pendingDebugEvents:Array = [];

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestEncryptionKey.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestEncryptionKey.as
@@ -22,7 +22,7 @@ package com.kaltura.hls.manifest
 	public class HLSManifestEncryptionKey extends EventDispatcher
 	{
 		private static const LOADER_CACHE:Dictionary = new Dictionary();
-		private var _key:  FastAESKey;
+		private var _key:FastAESKey;
 		public var usePadding:Boolean = false;
 		public var iv:String = "";
 		public var url:String = "";
@@ -159,29 +159,30 @@ package com.kaltura.hls.manifest
 			}
 			return decrypt;
 		}
-		public function unpad(a : ByteArray) : ByteArray {
-			var c : uint = a.length % 16;
-			if (c != 0) {
-				trace("PKCS#5::unpad: ByteArray.length isn't a multiple of the blockSize");
+		public function unpad(bytesToUnpad : ByteArray) : ByteArray {
+			if ((bytesToUnpad.length % 16) != 0)
+			{
+				throw new Error("PKCS#5::unpad: ByteArray.length isn't a multiple of the blockSize");
 				return a;
 			}
-			c = a[a.length - 1];
-			var success:Boolean = true;
-			var newLength:uint = a.length;
-			for (var i : uint = c; i > 0; i--) {
-				var v : uint = a[a.length - 1];
-				if (c != v) {
-					trace("PKCS#5:unpad: Invalid padding value. expected [" + c + "], found [" + v + "]");
-					success = false;
-					break;
+
+			const paddingValue:int = bytesToUnpad[bytesToUnpad.length - 1];
+			var doUnpad:Boolean = true;
+			for (var i:int = 0; i<paddingValue; i++) {
+				var readValue:int = bytesToUnpad[bytesToUnpad.length - (1 + i)];
+				if (paddingValue != readValue) {
+					//throw new Error("PKCS#5:unpad: Invalid padding value. expected [" + paddingValue + "], found [" + readValue + "]");
+					//break;
+					doUnpad = false;
 				}
-				newLength--;
 			}
-			if (success){
-				a.length = newLength;
-			}
-			return a;
+
+			if(doUnpad)
+				bytesToUnpad.length -= paddingValue;
+
+			return bytesToUnpad;
 		}
+
 		public function retrieveStoredIV():ByteArray
 		{
 			trace("IV of " + iv + " for " + url + ", key=" + Hex.fromArray(_keyData));

--- a/HLSPlugin/src/com/kaltura/hls/subtitles/TextTrackCue.as
+++ b/HLSPlugin/src/com/kaltura/hls/subtitles/TextTrackCue.as
@@ -103,6 +103,10 @@ package com.kaltura.hls.subtitles
 						// Not yet implemented
 						break;
 					
+					case "align":
+						// Not yet implemented
+						break;
+
 					case "size":
 						// Not yet implemented
 						break;

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
@@ -389,6 +389,11 @@ package org.osmf.net.httpstreaming
 
 		}
 		
+		public function get absoluteTime():Number
+		{
+			return super.time + _seekTime;
+		}
+
 		/**
 		 * @inheritDoc
 		 */

--- a/TestPlayer/src/TestPlayer.mxml
+++ b/TestPlayer/src/TestPlayer.mxml
@@ -10,6 +10,7 @@
 	<fx:Script>
 		<![CDATA[
 			import com.kaltura.hls.SubtitleTrait;
+			import com.kaltura.hls.SubtitleEvent;
 			import com.kaltura.hls.manifest.HLSManifestParser;
 			
 			import mx.collections.ArrayList;
@@ -307,12 +308,14 @@
 				}
 				
 				var subtitleTrait:SubtitleTrait = element.getTrait( SubtitleTrait.TYPE ) as SubtitleTrait;
-				
+
 				// Give the statistics window the subtitle Trait so it can turn them on and off
 				statisticsWindow.subtitleTrait = subtitleTrait;
 				
 				if ( subtitleTrait && subtitleTrait.languages.length > 0 )
 				{
+					subtitleTrait.addEventListener(SubtitleEvent.CUE, onSubtitleCue);
+
 					// Listen for the onTextData event
 					var localElem:MediaElement = element;
 					while (localElem is ProxyElement)
@@ -324,6 +327,12 @@
 					}
 				}
 				
+			}
+
+			private function onSubtitleCue(e:SubtitleEvent):void
+			{
+				trace("SUBTITLE: " + e.text);
+				subtitleLabel.text = e.text;
 			}
 			
 			private function onWrapperResize(event:ResizeEvent):void {
@@ -363,11 +372,19 @@
 			}
 			
 			private function onPlayChange(event:Event):void {
-				if (player.paused) {
-					player.play();
+				try 
+				{
+					if (player.paused) {
+						player.play();
+					}
+					else 
+					{
+						player.pause();
+					}					
 				}
-				else {
-					player.pause();
+				catch(e:*)
+				{
+					trace("Could not pause.");
 				}
 			}
 			
@@ -460,6 +477,10 @@
 				horizontalCenter="0"/>
 			
 		</s:Group>
+
+		<s:HGroup width="100%" verticalAlign="middle" gap="0" height="32">
+			<s:Label id="subtitleLabel" text="CAPTIONS" color="0xFFFFFF" width="100%" height="100%"/>
+		</s:HGroup>
 		
 		<s:HGroup width="100%" verticalAlign="middle" gap="0">
 			


### PR DESCRIPTION
Address FEC-2969 and SUP-5002.

Captions now processed outside of video stream for fast response to toggling them on/off and/or changing languages.

PLEASE NOTE - there is now a SubtitleEvent fired on the SubTitleTrait since we are no longer injecting captions into FLV. I looked for a way to mimic this and could not readily find it so you will have to adjust the KDP player a little bit.

Olive.fr stream shows captions for me with this - HOWEVER it does not have caption data for the entire DVR window so older segments can lack captions.

I also tried with the "Office Sports" stream and the "Welcome to Kaltura" VOD and get good results.

Please land #120 before landing this.