### PR TITLE
Don't feed PES start code into AAC processing logic.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/m2ts/FLVTranscoder.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/FLVTranscoder.as
@@ -282,8 +282,8 @@ package com.kaltura.hls.m2ts
             var limit:uint;
             var stream:ByteArray;
             var hadRemainder:Boolean = false;
-            var cursor:int = 0;
-            var length:int = pes.buffer.length;
+            var cursor:int = pes.headerLength;
+            var length:int = pes.buffer.length - pes.headerLength;
             var bytes:ByteArray = pes.buffer;
             var timestamp:Number = pes.pts;
             

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/PESPacket.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/PESPacket.as
@@ -27,6 +27,7 @@ package com.kaltura.hls.m2ts
             p.pts = pts;
             p.dts = dts;
             p.type = type;
+            p.headerLength = headerLength;
             return p;
         }
 
@@ -35,5 +36,7 @@ package com.kaltura.hls.m2ts
         public var pts:Number, dts:Number;
         public var packetID:int = -1;
         public var buffer:ByteArray = null;
+
+        public var headerLength:int = NaN;
     }
 }

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/PESProcessor.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/PESProcessor.as
@@ -302,6 +302,7 @@ package com.kaltura.hls.m2ts
 
             // Note the type at this moment in time.
             packet.type = types[packet.packetID];
+            packet.headerLength = cursor;
 
             // And process.
             if(MediaClass.calculate(types[packet.packetID]) == MediaClass.VIDEO)


### PR DESCRIPTION
Due to some prior changes we were incorrectly passing PES headers into the AAC processing code. This wasn't an issue most of the time (the AAC ADTS packets have their own header code that we scan for) but in this rare case it was misidentifying part of the PES header as an ADTS start and getting incorrect data. Modifying it to ignore the PES header fixed the issue.