### PR TITLE
Better bitrate switching and debug visualizer.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
@@ -1177,10 +1177,11 @@ package com.kaltura.hls
 				return new HTTPStreamRequest(HTTPStreamRequestKind.LIVE_STALL, null, 2);
 			}
 
-			// Advance sequence number if we didn't seed. This prevensts us from
+			// Advance sequence number if we didn't seed. This prevents us from
 			// inadvertantly advancing past the first segment of a video in streams 
-			// with non-zero start times.
-			if(!didWeSeedLastSequence)
+			// with non-zero start times. We also don't increment when moving across
+			// quality levels as the remap and low water systems handles any overlap.
+			if(!didWeSeedLastSequence && (currentManifest.fullUrl == getLastSequenceManifest().fullUrl))
 				newSequence++;
 
 			var segments:Vector.<HLSManifestSegment> = currentManifest.segments;

--- a/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
@@ -782,6 +782,9 @@ package com.kaltura.hls
 
 			stalled = false;
 			HLSHTTPNetStream.hasGottenManifest = true;
+
+			// Debug to JS.
+			manifest.postToJS();
 		}
 
 		public function getQualityLevelStreamName(index:int):String
@@ -916,6 +919,9 @@ package com.kaltura.hls
 					return new HTTPStreamRequest (HTTPStreamRequestKind.LIVE_STALL, null, SHORT_LIVE_STALL_DELAY);
 				}
 			}
+
+			// Debug to JS.
+			manifest.postToJS();
 
 			if(time < segments[0].startTime)
 			{
@@ -1143,6 +1149,10 @@ package com.kaltura.hls
 
 			// Attempt remap.
 			var newSequence:int = remapSequence(getLastSequenceManifest(), currentManifest, getLastSequence());
+
+			// Debug to JS.
+			manifest.postToJS();
+
 			if(newSequence == -1)
 			{
 				if(_pendingBestEffortRequest && !isBestEffortActive())

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -346,6 +346,10 @@ package com.kaltura.hls.m2ts
 			return basicProcessFileSegment(input || new ByteArray(), true);
 		}
 				
+		public static var flvLowWaterAudio:uint = 0;
+		public static var flvLowWaterVideo:uint = 0;
+		public const filterThresholdMs:uint = 0;
+
 		private function handleFLVMessage(timestamp:uint, message:ByteArray):void
 		{
 			var timestampSeconds:Number = timestamp / 1000.0;
@@ -379,9 +383,10 @@ package com.kaltura.hls.m2ts
 
 			if(type == 9)
 			{
-				if(timestamp < flvLowWaterVideo - 64 && !alwaysPass)
+				if(timestamp < flvLowWaterVideo - filterThresholdMs && !alwaysPass)
 				{
 					trace("SKIPPING TOO LOW FLV VID TS @ " + timestamp);
+					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false)");
 					return;
 				}
 
@@ -391,16 +396,17 @@ package com.kaltura.hls.m2ts
 			}
 			else if(type == 8)
 			{
-				if(timestamp < flvLowWaterAudio - 64)
+				if(timestamp < flvLowWaterAudio - filterThresholdMs)
 				{
 					trace("SKIPPING TOO LOW FLV AUD TS @ " + timestamp);
+					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false)");
 					return;
 				}
 
 				flvLowWaterAudio = timestamp;					
 			}
 
-			ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ")");
+			ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", true)");
 
 			//trace("Got " + message.length + " bytes at " + timestampSeconds + " seconds");
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -11,6 +11,8 @@ package com.kaltura.hls.m2ts
 	import flash.utils.ByteArray;
 	import flash.utils.IDataInput;
 	import flash.utils.getTimer;
+
+	import flash.external.ExternalInterface;
 	
 	import org.osmf.events.HTTPStreamingEvent;
 	import org.osmf.net.httpstreaming.HTTPStreamingFileHandlerBase;
@@ -352,6 +354,9 @@ package com.kaltura.hls.m2ts
 
 			if(isBestEffort)
 				return;
+
+			var type:int = message[0];
+			ExternalInterface.call("tag(" + timestampSeconds + ", " + type + ")");
 
 			//trace("Got " + message.length + " bytes at " + timestampSeconds + " seconds");
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -371,6 +371,7 @@ package com.kaltura.hls.m2ts
 
 			// Alway pass through SPS/PPS...
 			var alwaysPass:Boolean = false
+			var isKeyFrame:Boolean = false;
 			if(type == 9)
 			{
 				if(message[11] == FLVTags.VIDEO_CODEC_AVC_KEYFRAME
@@ -379,6 +380,9 @@ package com.kaltura.hls.m2ts
 					trace("Got AVCC, always pass");
 					alwaysPass = true;
 				}
+
+				if(message[11] == FLVTags.VIDEO_CODEC_AVC_KEYFRAME)
+					isKeyFrame = true;
 			}
 
 			if(type == 9)
@@ -386,7 +390,7 @@ package com.kaltura.hls.m2ts
 				if(timestamp < flvLowWaterVideo - filterThresholdMs && !alwaysPass)
 				{
 					trace("SKIPPING TOO LOW FLV VID TS @ " + timestamp);
-					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false)");
+					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false, " + isKeyFrame + ")");
 					return;
 				}
 
@@ -399,14 +403,14 @@ package com.kaltura.hls.m2ts
 				if(timestamp < flvLowWaterAudio - filterThresholdMs)
 				{
 					trace("SKIPPING TOO LOW FLV AUD TS @ " + timestamp);
-					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false)");
+					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false, " + isKeyFrame + ")");
 					return;
 				}
 
 				flvLowWaterAudio = timestamp;					
 			}
 
-			ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", true)");
+			ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", true, " + isKeyFrame + ")");
 
 			//trace("Got " + message.length + " bytes at " + timestampSeconds + " seconds");
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -390,7 +390,10 @@ package com.kaltura.hls.m2ts
 				if(timestamp < flvLowWaterVideo - filterThresholdMs && !alwaysPass)
 				{
 					trace("SKIPPING TOO LOW FLV VID TS @ " + timestamp);
-					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false, " + isKeyFrame + ")");
+					CONFIG::LOGGING
+					{
+						ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false, " + isKeyFrame + ")");
+					}
 					return;
 				}
 
@@ -403,14 +406,20 @@ package com.kaltura.hls.m2ts
 				if(timestamp < flvLowWaterAudio - filterThresholdMs)
 				{
 					trace("SKIPPING TOO LOW FLV AUD TS @ " + timestamp);
-					ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false, " + isKeyFrame + ")");
+					CONFIG::LOGGING
+					{
+						ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", false, " + isKeyFrame + ")");
+					}
 					return;
 				}
 
 				flvLowWaterAudio = timestamp;					
 			}
 
-			ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", true, " + isKeyFrame + ")");
+			CONFIG::LOGGING
+			{
+				ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ", true, " + isKeyFrame + ")");			
+			}
 
 			//trace("Got " + message.length + " bytes at " + timestampSeconds + " seconds");
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -400,6 +400,7 @@ package com.kaltura.hls.m2ts
 				flvLowWaterAudio = timestamp;					
 			}
 
+			ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + "," + flvLowWaterAudio + "," + flvLowWaterVideo + ")");
 
 			//trace("Got " + message.length + " bytes at " + timestampSeconds + " seconds");
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -315,7 +315,7 @@ package com.kaltura.hls.m2ts
 			var elapsed:Number = _segmentLastSeconds - _segmentBeginSeconds;
 			
 			// Also update end time - don't trace it as we'll increase it incrementally.
-			if(HLSIndexHandler.endTimeWitnesses[segmentUri] == null)
+			if(HLSIndexHandler.endTimeWitnesses[segmentUri] == null && !isBestEffort)
 			{
 				trace("Noting segment end time for " + segmentUri + " of " + _segmentLastSeconds);
 				if(_segmentLastSeconds != _segmentLastSeconds)

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -356,7 +356,7 @@ package com.kaltura.hls.m2ts
 				return;
 
 			var type:int = message[0];
-			ExternalInterface.call("tag(" + timestampSeconds + ", " + type + ")");
+			ExternalInterface.call("onTag(" + timestampSeconds + ", " + type + ")");
 
 			//trace("Got " + message.length + " bytes at " + timestampSeconds + " seconds");
 

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -105,7 +105,10 @@ package com.kaltura.hls.manifest
 			}
 
 			// Post it out.
-			ExternalInterface.call("onManifest", JSON.stringify(json));
+			CONFIG::LOGGING
+			{
+				ExternalInterface.call("onManifest", JSON.stringify(json));
+			}
 		}
 
 		public function parse(input:String, _fullUrl:String):void

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -2,6 +2,7 @@ package com.kaltura.hls.manifest
 {
 	import com.kaltura.hls.subtitles.SubTitleParser;
 	
+	import flash.external.ExternalInterface;
 	import flash.events.Event;
 	import flash.events.EventDispatcher;
 	import flash.events.IOErrorEvent;
@@ -81,6 +82,30 @@ package com.kaltura.hls.manifest
 			}
 
 			return ( uri.substr(0, 5) == "http:" || uri.substr(0, 6) == "https:" || uri.substr(0, 5) == "file:" ) ? uri : baseUrl + uri;
+		}
+
+		public function postToJS()
+		{
+			// Generate JSON state!
+			var json:Object = {};
+			for(var i:int=0; i<streams.length; i++)
+			{
+				var streamJson:Array = [];
+
+				if(!streams[i].manifest)
+					continue;
+
+				for(var j:int=0; j<streams[i].manifest.segments.length; j++)
+				{
+					var curSeg:HLSManifestSegment = streams[i].manifest.segments[j];
+					streamJson.push({ id: curSeg.id, url: curSeg.uri, start: curSeg.startTime, end: curSeg.startTime + curSeg.duration});
+				}
+
+				json[streams[i].uri] = streamJson;
+			}
+
+			// Post it out.
+			ExternalInterface.call("onManifest", JSON.stringify(json));
 		}
 
 		public function parse(input:String, _fullUrl:String):void

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
@@ -26,6 +26,7 @@ package org.osmf.net.httpstreaming
 	import flash.events.IEventDispatcher;
 	import flash.utils.ByteArray;
 	import flash.utils.IDataInput;
+	import flash.external.ExternalInterface;
 	
 	import org.osmf.events.DVRStreamInfoEvent;
 	import org.osmf.events.HTTPStreamingEvent;
@@ -430,6 +431,9 @@ package org.osmf.net.httpstreaming
 					{
 						_request = _indexHandler.getNextFile(_qualityLevel);
 					}
+
+					// Log the request.
+					ExternalInterface.call("onNextRequest", JSON.stringify({ url: _request.url }));
 					
 					// update _isLiveStalled so HTTPNetStream can access it.
 					// request.kind will always be LIVE_STALL as long as we are live stalled. 

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
@@ -433,7 +433,10 @@ package org.osmf.net.httpstreaming
 					}
 
 					// Log the request.
-					ExternalInterface.call("onNextRequest", JSON.stringify({ kind: _request.kind, url: _request.url }));
+					CONFIG::LOGGING
+					{
+						ExternalInterface.call("onNextRequest", JSON.stringify({ kind: _request.kind, url: _request.url }));
+					}
 					
 					// update _isLiveStalled so HTTPNetStream can access it.
 					// request.kind will always be LIVE_STALL as long as we are live stalled. 

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
@@ -433,7 +433,7 @@ package org.osmf.net.httpstreaming
 					}
 
 					// Log the request.
-					ExternalInterface.call("onNextRequest", JSON.stringify({ url: _request.url }));
+					ExternalInterface.call("onNextRequest", JSON.stringify({ kind: _request.kind, url: _request.url }));
 					
 					// update _isLiveStalled so HTTPNetStream can access it.
 					// request.kind will always be LIVE_STALL as long as we are live stalled. 

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,10 @@ OSMF/osmf.swc: $(shell find OSMF/ -name \*.as) Makefile
 		-optimize=${OPTIMIZE_FLAG} \
 		-output osmf.swc -include-sources . 
 
+clean:
+	@echo ============= Cleaning ========================
+	rm OSMF/osmf.swc
+	rm OSMFUtils/osmfutils.swc
+	rm HLSPlugin/hlsPlugin.swc
+	rm KalturaHLSPlugin/KalturaHLSPlugin.swf
+	rm TestPlayer/html-template/TestPlayer.swf

--- a/OSMF/org/osmf/net/httpstreaming/HTTPStreamDownloader.as
+++ b/OSMF/org/osmf/net/httpstreaming/HTTPStreamDownloader.as
@@ -32,6 +32,7 @@ package org.osmf.net.httpstreaming
 	import flash.utils.ByteArray;
 	import flash.utils.IDataInput;
 	import flash.utils.Timer;
+	import flash.external.ExternalInterface;
 	
 	import org.osmf.events.HTTPStreamingEvent;
 	import org.osmf.events.HTTPStreamingEventReason;
@@ -115,6 +116,11 @@ package org.osmf.net.httpstreaming
 		{
 			return _downloadBytesCount;
 		}
+
+		public function debugToJS(url:String, event:String):void
+		{
+           ExternalInterface.call("onDownload", JSON.stringify({url: url, event: event}));
+		}
 		
 		/**
 		 * Opens the HTTP stream source and start downloading the data 
@@ -131,6 +137,8 @@ package org.osmf.net.httpstreaming
 				throw new ArgumentError("Null request in HTTPStreamDownloader open method."); 
 			}
 			
+			debugToJS( request.url.toString(), "open");
+
 			_isComplete = false;
 			_hasData = false;
 			_hasErrors = false;
@@ -183,6 +191,9 @@ package org.osmf.net.httpstreaming
 		 **/ 
 		public function close(dispose:Boolean = false):void
 		{
+			if(_request && _request.url)
+				debugToJS( _request.url.toString(), "closed");
+
 			CONFIG::LOGGING
 			{
 				if (_request != null)
@@ -365,6 +376,8 @@ package org.osmf.net.httpstreaming
 		private function onOpen(event:Event):void
 		{
 			_isOpen = true;
+			debugToJS( _request.url.toString(), "opened");
+
 		}
 		
 		/**
@@ -373,6 +386,8 @@ package org.osmf.net.httpstreaming
 		 **/
 		private function onComplete(event:Event):void
 		{
+			debugToJS( _request.url.toString(), "complete");
+
 			if (_downloadBeginDate == null)
 			{
 				_downloadBeginDate = new Date();
@@ -474,6 +489,8 @@ package org.osmf.net.httpstreaming
 		 **/
 		private function onError(event:Event):void
 		{
+			debugToJS( _request.url.toString(), "error");
+
 			if (_timeoutTimer != null)
 			{
 				stopTimeoutMonitor();
@@ -552,6 +569,8 @@ package org.osmf.net.httpstreaming
 		 */ 
 		private function onTimeout(event:TimerEvent):void
 		{
+			debugToJS( _request.url.toString(), "timeout");
+
 			CONFIG::LOGGING
 			{
 				logger.error("Timeout while trying to download [" + _request.url + "]");

--- a/README.md
+++ b/README.md
@@ -38,3 +38,34 @@ Build them all to get the KalturaHLSPlugin.swf from the
 KalturaHLSPlugin/bin-debug folder. This may then be loaded in the Kaltura Player (or any OSMF-based player).
 
 **Note:** You have to make sure that you set the project references correctly or OSMF won't be bundled with the SWF, and errors will occur due to incompatible versions.
+
+Building With Make
+==================
+
+As an alternative to using Flash Builder, you may also use make to compile the plugins, libraries, and test player.
+
+1. The osmf.swc file must be removed from your 4.6.0 sdk folder (in 4.6.0/frameworks/libs)
+2. These lines must be changed to fit your local environment https://github.com/kaltura/HLS-OSMF/tree/master//Makefile#L6-L8, https://github.com/kaltura/HLS-OSMF/tree/master/OSMF/OSMF-build-config.xml#L69-L70, and https://github.com/kaltura/HLS-OSMF/tree/master/OSMFUtils/OSMFUtils-build-config.xml#L69-L70
+3. Comment out the reference to OSMF in the flex-onfig.xml file in your 4.6.0 sdk (4.6.0/frameworks/flex-config.xml). This may require you change permission settings.
+4. Run `make` in the base directory
+
+**NOTE:** In order to run the TestPlayer visualizer, and to enable extra logging, the CONFIG::LOGGING value must be set to true here: https://github.com/kaltura/HLS-OSMF/blob/master/HLSPlugin/HLS-build-config.xml#L12
+
+**NOTE 2:** The Makefile will only fully work on unix-like systems. If run on a DOS system, make will be unable to determine if files have been updated, and will require a manual clean before each new build. Additionally, the `make clean` command will not work. This means that for a manual clean, the built files must be deleted using the explorer.
+
+### The Debug Visualization 
+
+A full featured debug visualizer is included with the HLS OSMF plugin to help with development and testing. It visualises MPEGTS->FLV transcoding, segment download activity, and manifest state and segment selection.
+
+See TestPlayer/html-template/index.hml for details.
+
+The visualizer is written in HTML/JS and requires the plugin to call certain methods via ExternalInterface for proper functioning. Javascript callbacks only occur if CONFIG::LOGGING is true at compile time.
+Intructions follow to integrate the Debug Visualizer into your own web page.
+
+These instructions assume you are starting from the [index.template.html](https://github.com/kaltura/HLS-OSMF/blob/master/TestPlayer/html-template/index.template.html). Extrapolate these insstructions as required.
+
+1. Build the TestPlayer.swf. See "Building with Make" for instructions.
+2. Copy the [swfobject.js](https://github.com/kaltura/HLS-OSMF/blob/master/TestPlayer/html-template/swfobject.js]), [sources.xml](https://github.com/kaltura/HLS-OSMF/blob/master/TestPlayer/html-template/sources.xml), and the generated TestPlayer.swf into the index directory.
+3. Adjust the variables to fit your requirements, specifically, make sure ${swf} points to the location of the TestPlayer.swf.
+4. Copy the [visualizer script](https://github.com/kaltura/HLS-OSMF/blob/BJG-BetterBitSwitching/TestPlayer/html-template/index.html#L64-L585) into your index.html.
+5. Copy the [visualizer HTML Tags](https://github.com/kaltura/HLS-OSMF/blob/BJG-BetterBitSwitching/TestPlayer/html-template/index.html#L633-L636) into your index.html.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ As an alternative to using Flash Builder, you may also use make to compile the p
 
 ### The Debug Visualization 
 
+![Manifest Visualization](https://s3.amazonaws.com/uploads.hipchat.com/70076/1718358/QwaZnBtZ6wpAPMB/abc-live-throttled.png)
+![Transcoder and Download Visualization](https://s3.amazonaws.com/uploads.hipchat.com/70076/961665/q1B3iAV532gFnkY/YAY.PNG)
+
 A full featured debug visualizer is included with the HLS OSMF plugin to help with development and testing. It visualises MPEGTS->FLV transcoding, segment download activity, and manifest state and segment selection.
 
 See TestPlayer/html-template/index.hml for details.

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -413,7 +413,7 @@
                     
                     function timeToPixel(t)
                     {
-                        var n = (t - manGlobalMin) / (manGlobalMax - manGlobalMin);
+                        var n = ((t+timeOffset) - manGlobalMin) / (manGlobalMax - manGlobalMin);
                         return n * width; 
                     }
                     

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -433,7 +433,7 @@
                             
                             
                             // Apply animation to show requests.
-                            for(var q=0; q<requestLog.length; q++)
+                            for(var q=requestLog.length-1; q>=0; q--)
                             {
                                 var curRequestItem = requestLog[q];
                                 if(curRequestItem.url != curManItem.url)

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -60,36 +60,128 @@
             swfobject.createCSS("#flashContent", "display:block;text-align:left;");
         </script>
         
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
-        <script src="https://raw.githubusercontent.com/bgrins/TinyColor/master/tinycolor.js"></script>
         
         <script>
             /***
              * HLS OSMF plugin debug module.
              * 
-             * Draggable timeline of converted samples.
+             * This works with functionality in a debug build of the Kaltura 
+             * HLS OSMF plugin to render a debug visualization via HTML5 canvas.
+             * 
+             * Currently only tested on FireFox.
+             * 
+             * If you are color blind you may want to adjust the colors used for better
+             * visibility.
+             * 
+             * Several elements of player state are rendered in timeline form:
+             *      1. FLV tags submitted to HLS OSMF. These are drawn in three
+             *         tracks showing audio, video, and script tags. A vertical
+             *         tick mark shows each tag. Tags filtered by the low water
+             *         mark system are drawn red and shifted down. Video key frames 
+             *         (I-frames) are rendered with slightly taller ticks.
+             *      2. Active downloads are rendered as orange blocks.
+             *      3. If you switch modes, you can see the current manifest 
+             *         state. This is shown with a track per bitrate. Each
+             *         block represents a single segment. As knowledge is
+             *         gained about the playlists, the positions of the blocks
+             *         update. The color of manifests is changed as they are 
+             *         requested, with a slow fade to make it easy to spot 
+             *         who has changed in what order.
+             *      4. The playhead is rendered as a blue bar.
+             *      5. The audio/video low watermark thresholds are orange bars.
+             * 
+             * You can drag the views left and right, and zoom in/out using the 
+             * mousewheel.
+             * 
+             * If you go right as far as you can in the tag view, you will be at the
+             * newest data in OSMF's buffer. If you go left, it's the oldest. If it is
+             * to the left of the playhead it has been processed and removed from the system.
+             * 
+             * We purge old tags once they're no longer viewable to help avoid excessive
+             * memory bloat.
+             * 
+             * Note that the debug view and ExternalInterface calls cause some
+             * overhead when transcoding segments. Specifically, without careful
+             * attention, onTag calls can trigger browser rendering which can
+             * really slow things down. We have some thresholding and sanity
+             * logic to avoid this outcome. Mess with it at your own risk.
+             * 
+             * Manifest view does not work on manifests with no submanifests.
+             * 
+             * Views don't always update properly when playing new videos in the same
+             * session.
+             * 
+             * Seeking can also cause tags and downloads to "stack". This can cause degraded
+             * performance/incorrect visuals. 
+             * 
+             * For best results reload between each video play.
              */
              
+            // Current mode - "tags" showing FLV and downloads, or "manifest" showing playlist state.
             var mode="tags";
             
+            // Array containing info on FLV tags - {time: , type: , reject: , key: }
             var tags=[];
+            
+            // Epoch time of last tag call so we can avoid rendering immediately afterwards; this 
+            // helps avoid super slow transcoding.
             var lastTagSubmission = -1;
+            
+            // What was the last reported playhead time from HLS plugin?
             var playheadTime = 0;
+
+            // Set from HLS plugin, showing the cutoff for rejecting audio tags in ms.
+            var audioLowWatermark = 0;
+
+            // Set from HLS plugin, showing the cutoff for rejecting video tags in ms.
+            var videoLowWatermark = 0;
+            
+            // Current state of all downloads. Indexed by URL, each entry is an 
+            // array of {event:, time:} showing what's happened.
+            var downloadState = {};
+            
+            // Current state of all manifests. Structered as follows:
+            // {
+            //   "submanifest.m3u8": [
+            //        { id: 1, url: "seg.ts", startTime: 0.0, endTime: 10.0 }
+            //    ]
+            // }
+            var manifestState = {};
+
+            // List of what segments we've requested, in order. Used to highlight
+            // manifests.
+            // Entries are:  {url:, time: }
+            var requestLog = [];
+
+            // Set whenever we want to redraw.
             var bufferDirty = true;
+            
+            // We'll also re-render every few hundred ms to keep responsive.
             var lastBufferRender = 0;
             
-            var audioLowWatermark = 0;
-            var videoLowWatermark = 0;
-
+            // Have we set up our context and event listeners?
             var isSetup = false;
+            
+            // How far back from the head do we want to see? in seconds. 
             var howFarBack = 20;
+            
+            // Maximum distance allow zoom in seconds.
             var howFarBack_max = 120;
+            
+            // Minimum distance to show in zoom in seconds.
             var howFarBack_min = 1;
+            
+            // One mouse wheel event changes zoom by this many visible seconds?
             var howFarBack_step = 0.5;
-            var timeOffset_max = 120;
+                        
+            // Dimensions of the canvas tag.
             var width = 1024, height = 256;
+            
+            // How many px high is a track/lane/row?
             var rowHeight = 15;
 
+            // This maps FLV tag types to the row we want to display them. We also
+            // recognize "downloads" so we know how far down to start rendering downloads.
             var flvRowMap = {};
             flvRowMap[0x08] = 1;
             flvRowMap[0x09] = 2;
@@ -101,32 +193,25 @@
             var isDrag = false;
             var dragStartTime;
             
-            var timeOffset = 0; // seconds back from live to show
+            // Seconds back from live to translate the view.
+            var timeOffset = 0; 
 
-            var downloadState = {};
-            
-            var manifestState = {};
+            // Maximum amount to allow scrolling back.
+            var timeOffset_max = 120;
 
             // Initiate buffer rendering.
             requestAnimationFrame(redrawBuffer);
             setInterval(function() { bufferDirty = true; }, 100);
 
+            // Called by HLS plugin to update manifest state.
             function onManifest(payload)
             {
-                // We expect list of manifests...
-                /**
-                 * {
-                 *     "submanifest.m3u8": [
-                 *          { id: 1, url: "seg.ts", startTime: 0.0, endTime: 10.0 }
-                 *      ]
-                 * }
-                 */
                  manifestState = JSON.parse(payload);
                  bufferDirty = true;                 
             }
-            
-            var requestLog = []; // Contains {url:, time: }
-            
+                        
+            // Called by HLS plugin to note a request was made.
+            // This is associated with getNextFile/getFileForTime.
             function onNextRequest(payload)
             {
                 // Note the last requests so we can animate their state.
@@ -138,6 +223,7 @@
                 requestLog.push(payload);
             }
             
+            // Called by HLS plugin to note download events for segments.
             function onDownload(payload)
             {                
                 payload = JSON.parse(payload);   
@@ -164,13 +250,14 @@
                 bufferDirty = true;
             }
 
+            // Called by HLS plugin to note the current playhead time.
             function onCurrentTime(t, isAbsolute)
             {
                 playheadTime = t;
-                
                 bufferDirty = true;
             }
             
+            // Called by HLS plugin to note tag conversion state.
             function onTag(time, type, audioLow, videoLow, kept, isKey)
             {
                 // Note tag.
@@ -185,6 +272,7 @@
                 lastTagSubmission = Date.now();
             }
             
+            // Handle mousewheel events.
             function adjustZoom(e)
             {
                 var delta = -e.detail || e.wheelDelta;
@@ -198,7 +286,6 @@
                 e.preventDefault();
                 return false;
             }
-            
             
             function onMouseDown(e)
             {
@@ -219,6 +306,8 @@
                 // adjust time offset by deltaX.
                 var secondsToPixels = width / howFarBack;
                 var localOffset = deltaX / secondsToPixels;
+                
+                // Adjust and clamp it.
                 timeOffset = dragStartTime + localOffset;
                 timeOffset = Math.max(0, timeOffset);
                 timeOffset = Math.min(timeOffset_max, timeOffset);
@@ -231,6 +320,17 @@
                 isDrag = false;
             }
             
+            // Conversion helpers from http://stackoverflow.com/a/5624139
+            function componentToHex(c) {
+                var hex = parseInt(c).toString(16);
+                return hex.length == 1 ? "0" + hex : hex;
+            }
+            
+            function rgbToHex(r, g, b) {
+                return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+            }
+            
+            // Main function - renders player state.
             function redrawBuffer()
             {
                 // Keep processing.
@@ -296,21 +396,20 @@
                     
                     var currentItemIdx = tags.length - 1;
                     
-                    var highwater = {};
-                    
-                    // Skip back by the requested offset.
-                    //while(currentItemIdx >= 1 && tags[currentItemIdx].time > (lastTimestamp - timeOffset))
-                    // currentItemIdx--;
-                   
-                    while(currentItemIdx >= 0) // && tags[currentItemIdx].time >= (lastTimestamp - howFarBack))
+                    // Just draw all tags to avoid ordering issues making us drop tags as 
+                    // we scroll.                    
+                    while(currentItemIdx >= 0)
                     {
                         var tagType = tags[currentItemIdx].type;
                         var tagTime = tags[currentItemIdx].time;
+                        var tagReject = tags[currentItemIdx].reject;
                                                 
                         ctx.fillStyle = tags[currentItemIdx].reject ? "red" : "green";
                         ctx.fillRect(
                             width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
-                            flvRowMap[tags[currentItemIdx].type] * rowHeight, 1, tags[currentItemIdx].key ? rowHeight : rowHeight * 0.75);
+                            flvRowMap[tags[currentItemIdx].type] * rowHeight + (tagReject ? 3 : 0), 
+                            tags[currentItemIdx].key ? 2 : 1, 
+                            tags[currentItemIdx].key ? rowHeight : rowHeight * 0.75);
                         
                         currentItemIdx--;
                     }
@@ -341,10 +440,13 @@
                         var downloadName = visibleDownloads[i];
                         var stateArray = downloadState[downloadName];
     
+                        // We track download state as an array of events, get first
+                        // and last.
                         var firstTime = stateArray[0].time;
                         var lastState = stateArray[stateArray.length - 1].event;
                         var lastTime = stateArray[stateArray.length - 1].time;
                         
+                        // If it's ongoing, draw right edge as updating to now.
                         if(lastState == "open" || lastState == "opened")
                             lastTime = Date.now();
                         
@@ -384,33 +486,11 @@
                 }
                 else
                 {
-                    // Determine overall start/end times of all submanifests.
-                    var manGlobalMin = Number.MAX_VALUE;
-                    var manGlobalMax = 0;
-                    for(var manName in manifestState)
-                    {
-                        var localMin = Number.MAX_VALUE;
-                        var localMax = 0;
-                        
-                        var curManArray = manifestState[manName];
-                        for(var i=0; i<curManArray.length; i++)
-                        {
-                            var curManItem = curManArray[i];
-
-                            if(curManItem.start < 70000)
-                                continue;
-
-                            localMin = Math.min(localMin, curManItem.start);
-                            localMax = Math.max(localMax, curManItem.end);
-                        }
-                        
-                        manGlobalMin = Math.min(manGlobalMin, localMin);
-                        manGlobalMax = Math.max(manGlobalMax, localMax);
-                    }
-                    
+                    // Determine start/end of view based on zoom and current playhead.
                     manGlobalMax = playheadTime + howFarBack;
                     manGlobalMin = playheadTime - howFarBack;
                     
+                    // Helper to convert from times to pixels.
                     function timeToPixel(t)
                     {
                         var n = ((t+timeOffset) - manGlobalMin) / (manGlobalMax - manGlobalMin);
@@ -421,17 +501,20 @@
                     var curManIndex = 0;
                     for(var manName in manifestState)
                     {
-                        // Rows are submanifests                        
+                        // Rows are submanifests.
                         var curManArray = manifestState[manName];
                         var requestNotes = {};
+                        var color = {r: 128, g: 128, b: 128};
 
                         for(var i=0; i<curManArray.length; i++)
                         {
                             var curManItem = curManArray[i];
                             
-                            var color = {r: 128, g: 128, b: 128};
-                            
-                            
+                            // Reset color.
+                            color.r = 128;
+                            color.g = 128;
+                            color.b = 128;
+
                             // Apply animation to show requests.
                             for(var q=requestLog.length-1; q>=0; q--)
                             {
@@ -445,11 +528,12 @@
                                 color.g = gFactor;
                                 color.b = 200;
                                 
-                                requestNotes[curRequestItem.url] = " #" + q;
+                                requestNotes[curRequestItem.url] = " (request " + q + ")";
                                 break;
                             }                            
                             
-                            ctx.fillStyle = tinycolor(color).toHexString();
+                            // Draw the box with stroke.
+                            ctx.fillStyle = rgbToHex(color.r, color.g, color.b);
                             ctx.fillRect(
                                 timeToPixel(curManItem.start), 
                                 rowHeight * curManIndex * 2, 
@@ -465,6 +549,7 @@
                                 rowHeight * 2);
                         }
                         
+                        // Draw segment labels last so they aren't overlapped by boxes.
                         ctx.fillStyle = "black";
                         for(var i=0; i<curManArray.length; i++)
                         {
@@ -472,6 +557,7 @@
                             ctx.fillText("#" + curManItem.id + (requestNotes[curManItem.url] ? requestNotes[curManItem.url] : ""), timeToPixel(curManItem.start) + 5, rowHeight * curManIndex * 2);
                         }
 
+                        // Draw manifest name.
                         ctx.fillText(manName, 0, rowHeight * curManIndex * 2 + rowHeight);
                         
                         curManIndex++;
@@ -486,13 +572,14 @@
                 }
             }
             
+            // Event handler for the toggle button, to switch views.
             function onSwitchClick()
             {
                 if(mode == "tags")
                     mode = "manifest";
                 else
                     mode = "tags";
-                console.log("Now showing" + mode);
+                console.log("Now showing " + mode);
                 bufferDirty = true;
             }
         </script>
@@ -543,9 +630,9 @@
             </object>
         </noscript>
         
-        <!-- debug visualization -->
+        <!-- HLS OSMF debug visualization -->
         <br><hr>
-        <input type="button" value="Switch Mode" onclick="onSwitchClick()"/>
+        <input type="button" value="Switch Mode" onclick="onSwitchClick()"/><br>
         <canvas id="canvas" width="1024" height="256"></canvas>     
    </body>
 </html>

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -170,12 +170,13 @@
                 
                 bufferDirty = true;
             }
-
-            function onTag(time, type, audioLow, videoLow)
+            
+            function onTag(time, type, audioLow, videoLow, kept)
             {
                 // Note tag.
-                tags.push({time: time, type: type});
+                tags.push({time: time, type: type, reject: !kept});
 
+                // Update watermarks.
                 audioLowWatermark = audioLow / 1000;
                 videoLowWatermark = videoLow / 1000;
                                                 
@@ -236,7 +237,7 @@
                 requestAnimationFrame(redrawBuffer);
                 
                 // Suppress if we've gotten new tags really recently to avoid chug.
-                if(Date.now() - lastTagSubmission < 64 && Date.now() - lastBufferRender < 200)
+                if(Date.now() - lastTagSubmission < 64)
                     return;
                                     
                 // nop if no dirty.
@@ -305,16 +306,8 @@
                     {
                         var tagType = tags[currentItemIdx].type;
                         var tagTime = tags[currentItemIdx].time;
-                        
-                        var wasBackwards = false;
-    
-                        if(highwater[tagType] > tagTime)
-                            wasBackwards = true;
-                        
-                        if(highwater[tagType] < tagTime)
-                            highwater[tagType] = tagTime;
-                        
-                        ctx.fillStyle = wasBackwards ? "red" : "green";
+                                                
+                        ctx.fillStyle = tags[currentItemIdx].reject ? "red" : "green";
                         ctx.fillRect(
                             width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
                             flvRowMap[tags[currentItemIdx].type] * rowHeight, 1, rowHeight);

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -63,17 +63,23 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
         
         <script>
+            /***
+             * Debug interface.
+             * 
+             * Draggable timeline of converted samples.
+             */
             var tags=[];
             var bufferDirty = true;
 
             var isSetup = false;
             var howFarBack = 20;
             var width = 2048, height = 1024;
+            var rowHeight = 15;
 
             // Initiate buffer rendering.
-            setInterval(redrawBuffer, 100);
+            requestAnimationFrame(redrawBuffer);
 
-            function tag(time, type)
+            function tag(time, type, debugStr)
             {
                 // Note tag.
                 tags.push({time: time, type: type});
@@ -96,11 +102,51 @@
                 return false;
             }
             
+            var dragStartX, dragStartY;
+            var isDrag = false;
+            var dragStartTime;
+            
+            var timeOffset = 0; // seconds back from live to show
+            
+            function onMouseDown(e)
+            {
+                dragStartX = e.clientX;
+                dragStartY = e.clientY;
+                dragStartTime = timeOffset;
+                isDrag = true;                
+            }
+            
+            function onMouseMove(e)
+            {
+                if(isDrag == false)
+                    return false;
+                    
+                var deltaX = e.clientX - dragStartX;
+                var deltaY = e.clientY - dragStartY;
+                
+                // adjust time offset by deltaX.
+                var secondsToPixels = width / howFarBack;
+                var localOffset = deltaX / secondsToPixels;
+                timeOffset = dragStartTime + localOffset;
+                timeOffset = Math.max(0, timeOffset);
+                timeOffset = Math.min(45, timeOffset);
+                
+                bufferDirty = true;
+            }
+
+            function onMouseUp(e)
+            {
+                isDrag = false;
+            }
+            
             function redrawBuffer()
             {
+                // Keep processing.
+                requestAnimationFrame(redrawBuffer);
+                
+                // nop if no dirty.
                 if(bufferDirty == false)
                     return;
-
                 bufferDirty = false;
 
                 // Set up canvas.
@@ -111,9 +157,12 @@
                     console.log("Initializing tag debug view.");
                     this.window.addEventListener("mousewheel", adjustZoom, false);
                     this.window.addEventListener("DOMMouseScroll", adjustZoom, false);
+                    canvas.addEventListener("mousedown", onMouseDown, false);
+                    canvas.addEventListener("mousemove", onMouseMove, false);
+                    canvas.addEventListener("mouseup", onMouseUp, false);
                     isSetup = true;
                 }
-
+                
                 ctx.clearRect(0, 0, width, height)                
                 
                 if(tags.length == 0)
@@ -129,6 +178,12 @@
                 var currentItemIdx = tags.length - 1;
                 
                 var highwater = {};
+                
+                // Skip back by the requested offset.
+                while(currentItemIdx >= 1 && tags[currentItemIdx].time > (lastTimestamp - timeOffset))
+                    currentItemIdx--;
+               
+                lastTimestamp = tags[currentItemIdx].time;
                 
                 while(currentItemIdx >= 0 && tags[currentItemIdx].time >= (lastTimestamp - howFarBack))
                 {
@@ -146,10 +201,16 @@
                     ctx.fillStyle = wasBackwards ? "red" : "green";
                     ctx.fillRect(
                         width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
-                        tags[currentItemIdx].type * 10, 1, wasBackwards ? 30 : 10);
-                        
+                        tags[currentItemIdx].type * rowHeight, 1, rowHeight);
+                    
                     currentItemIdx--;
                 }
+                
+                // Draw row headers.
+                ctx.fillStyle = "black";
+                ctx.fillText("Audio", 0, 8 * rowHeight);
+                ctx.fillText("Video", 0, 9 * rowHeight);
+                ctx.fillText("Script", 0, 0x12 * rowHeight);
             }
         </script>
     </head>

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -131,7 +131,7 @@
             {
                 // Note the last requests so we can animate their state.
                 payload = JSON.parse(payload);
-                if(payload.url == null)
+                if(payload.url == null || payload.kind == "bestEffortDownload")
                     return;
                     
                 payload.time = Date.now();
@@ -423,12 +423,14 @@
                     {
                         // Rows are submanifests                        
                         var curManArray = manifestState[manName];
+                        var requestNotes = {};
 
                         for(var i=0; i<curManArray.length; i++)
                         {
                             var curManItem = curManArray[i];
                             
                             var color = {r: 128, g: 128, b: 128};
+                            
                             
                             // Apply animation to show requests.
                             for(var q=0; q<requestLog.length; q++)
@@ -442,6 +444,8 @@
                                 color.r = 200;
                                 color.g = gFactor;
                                 color.b = 200;
+                                
+                                requestNotes[curRequestItem.url] = " #" + q;
                                 break;
                             }                            
                             
@@ -465,10 +469,9 @@
                         for(var i=0; i<curManArray.length; i++)
                         {
                             var curManItem = curManArray[i];
-                            ctx.fillText("#" + curManItem.id, timeToPixel(curManItem.start) + 5, rowHeight * curManIndex * 2);
+                            ctx.fillText("#" + curManItem.id + (requestNotes[curManItem.url] ? requestNotes[curManItem.url] : ""), timeToPixel(curManItem.start) + 5, rowHeight * curManIndex * 2);
                         }
 
-                        ctx.fillStyle = "black";
                         ctx.fillText(manName, 0, rowHeight * curManIndex * 2 + rowHeight);
                         
                         curManIndex++;

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -59,6 +59,99 @@
             // JavaScript enabled so display the flashContent div in case it is not replaced with a swf object.
             swfobject.createCSS("#flashContent", "display:block;text-align:left;");
         </script>
+        
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
+        
+        <script>
+            var tags=[];
+            var bufferDirty = true;
+
+            var isSetup = false;
+            var howFarBack = 20;
+            var width = 2048, height = 1024;
+
+            // Initiate buffer rendering.
+            setInterval(redrawBuffer, 100);
+
+            function tag(time, type)
+            {
+                // Note tag.
+                tags.push({time: time, type: type});
+                
+                // Mark redraw needed.
+                bufferDirty = true;
+            }
+            
+            function adjustZoom(e)
+            {
+                var delta = -e.detail || e.wheelDelta;
+                
+                if(delta < 0)
+                    howFarBack = Math.max(1, howFarBack - 0.5);
+                else
+                    howFarBack = Math.min(45, howFarBack + 0.5);
+                    
+                bufferDirty = true;
+                e.preventDefault();
+                return false;
+            }
+            
+            function redrawBuffer()
+            {
+                if(bufferDirty == false)
+                    return;
+
+                bufferDirty = false;
+
+                // Set up canvas.
+                var canvas = document.getElementById("canvas");
+                var ctx = canvas.getContext("2d");
+                if(!isSetup)
+                {
+                    console.log("Initializing tag debug view.");
+                    this.window.addEventListener("mousewheel", adjustZoom, false);
+                    this.window.addEventListener("DOMMouseScroll", adjustZoom, false);
+                    isSetup = true;
+                }
+
+                ctx.clearRect(0, 0, width, height)                
+                
+                if(tags.length == 0)
+                    return;
+                
+                // Get last time.
+                var lastItem = tags[tags.length-1];
+                
+                // Draw up to a certain number of seconds back.
+                var secondsToPixels = width / howFarBack;
+                var lastTimestamp = lastItem.time;
+                
+                var currentItemIdx = tags.length - 1;
+                
+                var highwater = {};
+                
+                while(currentItemIdx >= 0 && tags[currentItemIdx].time >= (lastTimestamp - howFarBack))
+                {
+                    var tagType = tags[currentItemIdx].type;
+                    var tagTime = tags[currentItemIdx].time;
+                    
+                    var wasBackwards = false;
+
+                    if(highwater[tagType] > tagTime)
+                        wasBackwards = true;
+                    
+                    if(highwater[tagType] < tagTime)
+                        highwater[tagType] = tagTime;
+                    
+                    ctx.fillStyle = wasBackwards ? "red" : "green";
+                    ctx.fillRect(
+                        width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
+                        tags[currentItemIdx].type * 10, 1, wasBackwards ? 30 : 10);
+                        
+                    currentItemIdx--;
+                }
+            }
+        </script>
     </head>
     <body>
         <!-- SWFObject's dynamic embed method replaces this alternative HTML content with Flash content when enough 
@@ -104,6 +197,9 @@
                 </object>
                 <!--<![endif]-->
             </object>
-        </noscript>     
+        </noscript>
+        
+        <!-- debug visualization -->
+        <canvas id="canvas" width="2048" height="1024"></canvas>     
    </body>
 </html>

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -61,6 +61,7 @@
         </script>
         
         <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
+        <script src="https://raw.githubusercontent.com/bgrins/TinyColor/master/tinycolor.js"></script>
         
         <script>
             /***
@@ -75,6 +76,10 @@
             var lastTagSubmission = -1;
             var playheadTime = 0;
             var bufferDirty = true;
+            var lastBufferRender = 0;
+            
+            var audioLowWatermark = 0;
+            var videoLowWatermark = 0;
 
             var isSetup = false;
             var howFarBack = 20;
@@ -120,6 +125,19 @@
                  bufferDirty = true;                 
             }
             
+            var requestLog = []; // Contains {url:, time: }
+            
+            function onNextRequest(payload)
+            {
+                // Note the last requests so we can animate their state.
+                payload = JSON.parse(payload);
+                if(payload.url == null)
+                    return;
+                    
+                payload.time = Date.now();
+                requestLog.push(payload);
+            }
+            
             function onDownload(payload)
             {                
                 payload = JSON.parse(payload);   
@@ -153,11 +171,14 @@
                 bufferDirty = true;
             }
 
-            function onTag(time, type, debugStr)
+            function onTag(time, type, audioLow, videoLow)
             {
                 // Note tag.
                 tags.push({time: time, type: type});
-                                
+
+                audioLowWatermark = audioLow / 1000;
+                videoLowWatermark = videoLow / 1000;
+                                                
                 // Mark redraw needed.
                 bufferDirty = true;
                 lastTagSubmission = Date.now();
@@ -215,18 +236,30 @@
                 requestAnimationFrame(redrawBuffer);
                 
                 // Suppress if we've gotten new tags really recently to avoid chug.
-                if(Date.now() - lastTagSubmission < 64)
+                if(Date.now() - lastTagSubmission < 64 && Date.now() - lastBufferRender < 200)
                     return;
-                
+                                    
                 // nop if no dirty.
                 if(bufferDirty == false)
                     return;
                 bufferDirty = false;
+                lastBufferRender = Date.now();
 
-                // Truncate the buffer to last few items.
+                // Truncate the buffer to 2*howFarBack if we exceed some max...
                 var cleanThreshold = 25000;
                 if(tags.length > cleanThreshold * 1.1)
-                    tags = tags.slice(Math.max(tags.length - cleanThreshold, 1))
+                {
+                    var lastTime = tags[tags.length-1].time;
+                    for(var i=0; i<tags.length; i++)
+                    {
+                        if((lastTime - tags[i].time) < howFarBack_max)
+                            continue;
+                        
+                        // Remove.
+                        tags.splice(i, 1);
+                        i--;                         
+                    }
+                }
 
                 // Set up canvas.
                 var canvas = document.getElementById("canvas");
@@ -258,19 +291,17 @@
                     
                     // Draw up to a certain number of seconds back.
                     var secondsToPixels = width / howFarBack;
-                    var lastTimestamp = lastItem.time;
+                    var lastTimestamp = lastItem.time - timeOffset;
                     
                     var currentItemIdx = tags.length - 1;
                     
                     var highwater = {};
                     
                     // Skip back by the requested offset.
-                    while(currentItemIdx >= 1 && tags[currentItemIdx].time > (lastTimestamp - timeOffset))
-                        currentItemIdx--;
+                    //while(currentItemIdx >= 1 && tags[currentItemIdx].time > (lastTimestamp - timeOffset))
+                    // currentItemIdx--;
                    
-                    lastTimestamp = tags[currentItemIdx].time;
-                    
-                    while(currentItemIdx >= 0 && tags[currentItemIdx].time >= (lastTimestamp - howFarBack))
+                    while(currentItemIdx >= 0) // && tags[currentItemIdx].time >= (lastTimestamp - howFarBack))
                     {
                         var tagType = tags[currentItemIdx].type;
                         var tagTime = tags[currentItemIdx].time;
@@ -341,7 +372,16 @@
                     ctx.fillRect(
                         width - (lastTimestamp - playheadTime) * secondsToPixels,
                         0, 2, rowHeight * 3);
-                    
+
+                    // Draw watermarks.
+                    ctx.fillStyle = "orange";
+                    ctx.fillRect(
+                        width - (lastTimestamp - (audioLowWatermark - 0.100)) * secondsToPixels,
+                        flvRowMap[8] * rowHeight, 2, rowHeight);
+                    ctx.fillRect(
+                        width - (lastTimestamp - (videoLowWatermark - 0.100)) * secondsToPixels,
+                        flvRowMap[9] * rowHeight, 2, rowHeight);
+
                     // Draw row headers.
                     ctx.fillStyle = "black";
                     ctx.fillText("Audio", 0, flvRowMap[8] * rowHeight);
@@ -390,17 +430,35 @@
                     {
                         // Rows are submanifests                        
                         var curManArray = manifestState[manName];
-                        ctx.fillStyle = "DarkKhaki";
+
                         for(var i=0; i<curManArray.length; i++)
                         {
                             var curManItem = curManArray[i];
                             
+                            var color = {r: 128, g: 128, b: 128};
+                            
+                            // Apply animation to show requests.
+                            for(var q=0; q<requestLog.length; q++)
+                            {
+                                var curRequestItem = requestLog[q];
+                                if(curRequestItem.url != curManItem.url)
+                                    continue;
+                                
+                                var fadeTimeInMs = 4000;
+                                var gFactor = Math.min(255, (Date.now() - curRequestItem.time) / fadeTimeInMs * 255); 
+                                color.r = 200;
+                                color.g = gFactor;
+                                color.b = 200;
+                                break;
+                            }                            
+                            
+                            ctx.fillStyle = tinycolor(color).toHexString();
                             ctx.fillRect(
                                 timeToPixel(curManItem.start), 
                                 rowHeight * curManIndex * 2, 
                                 timeToPixel(curManItem.end) - timeToPixel(curManItem.start), 
                                 rowHeight * 2);
-                                
+                            
                             ctx.lineStyle = "black";
                             ctx.lineWidth = 2;
                             ctx.strokeRect(

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -69,7 +69,7 @@
              * Draggable timeline of converted samples.
              */
              
-            var mode="manifest";
+            var mode="tags";
             
             var tags=[];
             var lastTagSubmission = -1;
@@ -423,6 +423,16 @@
                     
                 }
             }
+            
+            function onSwitchClick()
+            {
+                if(mode == "tags")
+                    mode = "manifest";
+                else
+                    mode = "tags";
+                console.log("Now showing" + mode);
+                bufferDirty = true;
+            }
         </script>
     </head>
     <body>
@@ -472,6 +482,8 @@
         </noscript>
         
         <!-- debug visualization -->
+        <br><hr>
+        <input type="button" value="Switch Mode" onclick="onSwitchClick()"/>
         <canvas id="canvas" width="1024" height="256"></canvas>     
    </body>
 </html>

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -86,6 +86,7 @@
             flvRowMap[0x08] = 1;
             flvRowMap[0x09] = 2;
             flvRowMap[0x12] = 3;
+            flvRowMap["downloads"] = 4;
 
             // Drag state.
             var dragStartX, dragStartY;
@@ -94,8 +95,38 @@
             
             var timeOffset = 0; // seconds back from live to show
 
+            var downloadState = {};
+
             // Initiate buffer rendering.
             requestAnimationFrame(redrawBuffer);
+            setInterval(function() { bufferDirty = true; }, 100);
+
+            
+            function onDownload(payload)
+            {                
+                payload = JSON.parse(payload);   
+                // Events are:
+                //      open - just opened.
+                //      opened - open completed.
+                //      closed - code requested close.
+                //      complete - successful complete.
+                //      error - got an error and failed
+                //      timeout - timed out and failed.
+                
+                if(payload.event == "closed")
+                    return;
+                
+                if(payload.url.indexOf("?") != -1)
+                    payload.url = payload.url.split("?")[0];
+                
+                if(!downloadState[payload.url])
+                    downloadState[payload.url] = [];
+                
+                // Log the active state.
+                downloadState[payload.url].push({event: payload.event, time: Date.now()});
+                
+                bufferDirty = true;
+            }
 
             function onCurrentTime(t, isAbsolute)
             {
@@ -108,7 +139,7 @@
             {
                 // Note tag.
                 tags.push({time: time, type: type});
-                
+                                
                 // Mark redraw needed.
                 bufferDirty = true;
                 lastTagSubmission = Date.now();
@@ -165,7 +196,7 @@
                 // Keep processing.
                 requestAnimationFrame(redrawBuffer);
                 
-                // Suppress if we've gotten new tags really recently.
+                // Suppress if we've gotten new tags really recently to avoid chug.
                 if(Date.now() - lastTagSubmission < 64)
                     return;
                 
@@ -173,6 +204,11 @@
                 if(bufferDirty == false)
                     return;
                 bufferDirty = false;
+
+                // Truncate the buffer to last few items.
+                var cleanThreshold = 25000;
+                if(tags.length > cleanThreshold * 1.1)
+                    tags = tags.slice(Math.max(tags.length - cleanThreshold, 1))
 
                 // Set up canvas.
                 var canvas = document.getElementById("canvas");
@@ -189,7 +225,8 @@
                 }
                 
                 ctx.clearRect(0, 0, width, height)                
-                
+                ctx.textBaseline = "top";
+               
                 if(tags.length == 0)
                     return;
                 
@@ -231,17 +268,63 @@
                     currentItemIdx--;
                 }
                 
+                // Layout and draw downloads.
+                var msToPixels = secondsToPixels / 1000;
+                                
+                // Get the set of visible downloads.
+                var visibleDownloads = [];
+                for(var downloadName in downloadState)
+                {
+                    var stateArray = downloadState[downloadName];
+                    if(!stateArray || stateArray.length == 0)
+                        continue;
+                        
+                    var firstTime = stateArray[0].time;
+                    var lastTime = stateArray[stateArray.length - 1].time;
+                    
+                    if(Math.max(firstTime, Date.now() - (width / msToPixels)) <= Math.min(lastTime, Date.now()))
+                    {
+                        visibleDownloads.push(downloadName);                     
+                    }
+                }
+                
+                // Draw active downloads.
+                for(var i=0; i<visibleDownloads.length; i++)
+                {
+                    var downloadName = visibleDownloads[i];
+                    var stateArray = downloadState[downloadName];
+
+                    var firstTime = stateArray[0].time;
+                    var lastState = stateArray[stateArray.length - 1].event;
+                    var lastTime = stateArray[stateArray.length - 1].time;
+                    
+                    if(lastState == "open" || lastState == "opened")
+                        lastTime = Date.now();
+                    
+                    var firstX = width - (Date.now() - firstTime) * msToPixels; 
+                    var lastX = width - (Date.now() - lastTime) * msToPixels;
+                    
+                    // Get just the filename.
+                    var truncatedFile = downloadName.replace(/^.*[\\\/]/, '');
+                    
+                    ctx.fillStyle = "orange";
+                    ctx.fillRect(firstX, (flvRowMap["downloads"] + i) * rowHeight, lastX - firstX, rowHeight);
+                    ctx.fillStyle = "black";
+                    ctx.fillText(truncatedFile + ":" + lastState, firstX + 2, (flvRowMap["downloads"] + i) * rowHeight);
+                }
+                
                 // Draw playhead.
                 ctx.fillStyle = "blue";
                 ctx.fillRect(
                     width - (lastTimestamp - playheadTime) * secondsToPixels,
-                    0, 2, height);
+                    0, 2, rowHeight * 3);
                 
                 // Draw row headers.
                 ctx.fillStyle = "black";
                 ctx.fillText("Audio", 0, flvRowMap[8] * rowHeight);
                 ctx.fillText("Video", 0, flvRowMap[9] * rowHeight);
                 ctx.fillText("Script", 0, flvRowMap[0x12] * rowHeight);
+                ctx.fillText("Downloads", 0, flvRowMap["downloads"] * rowHeight);
             }
         </script>
     </head>

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -68,6 +68,9 @@
              * 
              * Draggable timeline of converted samples.
              */
+             
+            var mode="manifest";
+            
             var tags=[];
             var lastTagSubmission = -1;
             var playheadTime = 0;
@@ -96,11 +99,26 @@
             var timeOffset = 0; // seconds back from live to show
 
             var downloadState = {};
+            
+            var manifestState = {};
 
             // Initiate buffer rendering.
             requestAnimationFrame(redrawBuffer);
             setInterval(function() { bufferDirty = true; }, 100);
 
+            function onManifest(payload)
+            {
+                // We expect list of manifests...
+                /**
+                 * {
+                 *     "submanifest.m3u8": [
+                 *          { id: 1, url: "seg.ts", startTime: 0.0, endTime: 10.0 }
+                 *      ]
+                 * }
+                 */
+                 manifestState = JSON.parse(payload);
+                 bufferDirty = true;                 
+            }
             
             function onDownload(payload)
             {                
@@ -224,107 +242,186 @@
                     isSetup = true;
                 }
                 
+                // Clear the canvas.
                 ctx.clearRect(0, 0, width, height)                
                 ctx.textBaseline = "top";
-               
-                if(tags.length == 0)
-                    return;
-                
-                // Get last time.
-                var lastItem = tags[tags.length-1];
-                
-                // Draw up to a certain number of seconds back.
-                var secondsToPixels = width / howFarBack;
-                var lastTimestamp = lastItem.time;
-                
-                var currentItemIdx = tags.length - 1;
-                
-                var highwater = {};
-                
-                // Skip back by the requested offset.
-                while(currentItemIdx >= 1 && tags[currentItemIdx].time > (lastTimestamp - timeOffset))
-                    currentItemIdx--;
-               
-                lastTimestamp = tags[currentItemIdx].time;
-                
-                while(currentItemIdx >= 0 && tags[currentItemIdx].time >= (lastTimestamp - howFarBack))
-                {
-                    var tagType = tags[currentItemIdx].type;
-                    var tagTime = tags[currentItemIdx].time;
-                    
-                    var wasBackwards = false;
 
-                    if(highwater[tagType] > tagTime)
-                        wasBackwards = true;
-                    
-                    if(highwater[tagType] < tagTime)
-                        highwater[tagType] = tagTime;
-                    
-                    ctx.fillStyle = wasBackwards ? "red" : "green";
-                    ctx.fillRect(
-                        width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
-                        flvRowMap[tags[currentItemIdx].type] * rowHeight, 1, rowHeight);
-                    
-                    currentItemIdx--;
-                }
-                
-                // Layout and draw downloads.
-                var msToPixels = secondsToPixels / 1000;
-                                
-                // Get the set of visible downloads.
-                var visibleDownloads = [];
-                for(var downloadName in downloadState)
+                if(mode == "tags")
                 {
-                    var stateArray = downloadState[downloadName];
-                    if(!stateArray || stateArray.length == 0)
-                        continue;
-                        
-                    var firstTime = stateArray[0].time;
-                    var lastTime = stateArray[stateArray.length - 1].time;
+                    // Draw FLV/download state.
                     
-                    if(Math.max(firstTime, Date.now() - (width / msToPixels)) <= Math.min(lastTime, Date.now()))
+                    if(tags.length == 0)
+                        return;
+                    
+                    // Get last time.
+                    var lastItem = tags[tags.length-1];
+                    
+                    // Draw up to a certain number of seconds back.
+                    var secondsToPixels = width / howFarBack;
+                    var lastTimestamp = lastItem.time;
+                    
+                    var currentItemIdx = tags.length - 1;
+                    
+                    var highwater = {};
+                    
+                    // Skip back by the requested offset.
+                    while(currentItemIdx >= 1 && tags[currentItemIdx].time > (lastTimestamp - timeOffset))
+                        currentItemIdx--;
+                   
+                    lastTimestamp = tags[currentItemIdx].time;
+                    
+                    while(currentItemIdx >= 0 && tags[currentItemIdx].time >= (lastTimestamp - howFarBack))
                     {
-                        visibleDownloads.push(downloadName);                     
+                        var tagType = tags[currentItemIdx].type;
+                        var tagTime = tags[currentItemIdx].time;
+                        
+                        var wasBackwards = false;
+    
+                        if(highwater[tagType] > tagTime)
+                            wasBackwards = true;
+                        
+                        if(highwater[tagType] < tagTime)
+                            highwater[tagType] = tagTime;
+                        
+                        ctx.fillStyle = wasBackwards ? "red" : "green";
+                        ctx.fillRect(
+                            width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
+                            flvRowMap[tags[currentItemIdx].type] * rowHeight, 1, rowHeight);
+                        
+                        currentItemIdx--;
                     }
-                }
-                
-                // Draw active downloads.
-                for(var i=0; i<visibleDownloads.length; i++)
-                {
-                    var downloadName = visibleDownloads[i];
-                    var stateArray = downloadState[downloadName];
-
-                    var firstTime = stateArray[0].time;
-                    var lastState = stateArray[stateArray.length - 1].event;
-                    var lastTime = stateArray[stateArray.length - 1].time;
                     
-                    if(lastState == "open" || lastState == "opened")
-                        lastTime = Date.now();
+                    // Layout and draw downloads.
+                    var msToPixels = secondsToPixels / 1000;
+                                    
+                    // Get the set of visible downloads.
+                    var visibleDownloads = [];
+                    for(var downloadName in downloadState)
+                    {
+                        var stateArray = downloadState[downloadName];
+                        if(!stateArray || stateArray.length == 0)
+                            continue;
+                            
+                        var firstTime = stateArray[0].time;
+                        var lastTime = stateArray[stateArray.length - 1].time;
+                        
+                        if(Math.max(firstTime, Date.now() - (width / msToPixels)) <= Math.min(lastTime, Date.now()))
+                        {
+                            visibleDownloads.push(downloadName);                     
+                        }
+                    }
                     
-                    var firstX = width - (Date.now() - firstTime) * msToPixels; 
-                    var lastX = width - (Date.now() - lastTime) * msToPixels;
+                    // Draw active downloads.
+                    for(var i=0; i<visibleDownloads.length; i++)
+                    {
+                        var downloadName = visibleDownloads[i];
+                        var stateArray = downloadState[downloadName];
+    
+                        var firstTime = stateArray[0].time;
+                        var lastState = stateArray[stateArray.length - 1].event;
+                        var lastTime = stateArray[stateArray.length - 1].time;
+                        
+                        if(lastState == "open" || lastState == "opened")
+                            lastTime = Date.now();
+                        
+                        var firstX = width - (Date.now() - firstTime) * msToPixels; 
+                        var lastX = width - (Date.now() - lastTime) * msToPixels;
+                        
+                        // Get just the filename.
+                        var truncatedFile = downloadName.replace(/^.*[\\\/]/, '');
+                        
+                        ctx.fillStyle = "orange";
+                        ctx.fillRect(firstX, (flvRowMap["downloads"] + i) * rowHeight, lastX - firstX, rowHeight);
+                        ctx.fillStyle = "black";
+                        ctx.fillText(truncatedFile + ":" + lastState, firstX + 2, (flvRowMap["downloads"] + i) * rowHeight);
+                    }
                     
-                    // Get just the filename.
-                    var truncatedFile = downloadName.replace(/^.*[\\\/]/, '');
+                    // Draw playhead.
+                    ctx.fillStyle = "blue";
+                    ctx.fillRect(
+                        width - (lastTimestamp - playheadTime) * secondsToPixels,
+                        0, 2, rowHeight * 3);
                     
-                    ctx.fillStyle = "orange";
-                    ctx.fillRect(firstX, (flvRowMap["downloads"] + i) * rowHeight, lastX - firstX, rowHeight);
+                    // Draw row headers.
                     ctx.fillStyle = "black";
-                    ctx.fillText(truncatedFile + ":" + lastState, firstX + 2, (flvRowMap["downloads"] + i) * rowHeight);
+                    ctx.fillText("Audio", 0, flvRowMap[8] * rowHeight);
+                    ctx.fillText("Video", 0, flvRowMap[9] * rowHeight);
+                    ctx.fillText("Script", 0, flvRowMap[0x12] * rowHeight);
+                    ctx.fillText("Downloads", 0, flvRowMap["downloads"] * rowHeight);                    
                 }
-                
-                // Draw playhead.
-                ctx.fillStyle = "blue";
-                ctx.fillRect(
-                    width - (lastTimestamp - playheadTime) * secondsToPixels,
-                    0, 2, rowHeight * 3);
-                
-                // Draw row headers.
-                ctx.fillStyle = "black";
-                ctx.fillText("Audio", 0, flvRowMap[8] * rowHeight);
-                ctx.fillText("Video", 0, flvRowMap[9] * rowHeight);
-                ctx.fillText("Script", 0, flvRowMap[0x12] * rowHeight);
-                ctx.fillText("Downloads", 0, flvRowMap["downloads"] * rowHeight);
+                else
+                {
+                    // Determine overall start/end times of all submanifests.
+                    var manGlobalMin = Number.MAX_VALUE;
+                    var manGlobalMax = 0;
+                    for(var manName in manifestState)
+                    {
+                        var localMin = Number.MAX_VALUE;
+                        var localMax = 0;
+                        
+                        var curManArray = manifestState[manName];
+                        for(var i=0; i<curManArray.length; i++)
+                        {
+                            var curManItem = curManArray[i];
+
+                            if(curManItem.start < 70000)
+                                continue;
+
+                            localMin = Math.min(localMin, curManItem.start);
+                            localMax = Math.max(localMax, curManItem.end);
+                        }
+                        
+                        manGlobalMin = Math.min(manGlobalMin, localMin);
+                        manGlobalMax = Math.max(manGlobalMax, localMax);
+                    }
+                    
+                    manGlobalMax = playheadTime + howFarBack;
+                    manGlobalMin = playheadTime - howFarBack;
+                    
+                    function timeToPixel(t)
+                    {
+                        var n = (t - manGlobalMin) / (manGlobalMax - manGlobalMin);
+                        return n * width; 
+                    }
+                    
+                    // Draw manifest state.
+                    var curManIndex = 0;
+                    for(var manName in manifestState)
+                    {
+                        // Rows are submanifests                        
+                        var curManArray = manifestState[manName];
+                        ctx.fillStyle = "DarkKhaki";
+                        for(var i=0; i<curManArray.length; i++)
+                        {
+                            var curManItem = curManArray[i];
+                            
+                            ctx.fillRect(
+                                timeToPixel(curManItem.start), 
+                                rowHeight * curManIndex * 2, 
+                                timeToPixel(curManItem.end) - timeToPixel(curManItem.start), 
+                                rowHeight * 2);
+                        }
+                        
+                        ctx.fillStyle = "black";
+                        for(var i=0; i<curManArray.length; i++)
+                        {
+                            var curManItem = curManArray[i];
+                            ctx.fillText("#" + curManItem.id, timeToPixel(curManItem.start) + 5, rowHeight * curManIndex * 2);
+                        }
+
+                        ctx.fillStyle = "black";
+                        ctx.fillText(manName, 0, rowHeight * curManIndex * 2 + rowHeight);
+                        
+                        curManIndex++;
+                    }
+                    
+                    // Draw playhead.
+                    ctx.fillStyle = "blue";
+                    ctx.fillRect(
+                        timeToPixel(playheadTime),
+                        0, 2, rowHeight * curManIndex * 2);
+                    
+                }
             }
         </script>
     </head>

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -69,23 +69,49 @@
              * Draggable timeline of converted samples.
              */
             var tags=[];
+            var lastTagSubmission = -1;
+            var playheadTime = 0;
             var bufferDirty = true;
 
             var isSetup = false;
             var howFarBack = 20;
-            var width = 2048, height = 1024;
+            var howFarBack_max = 120;
+            var howFarBack_min = 1;
+            var howFarBack_step = 0.5;
+            var timeOffset_max = 120;
+            var width = 1024, height = 256;
             var rowHeight = 15;
+
+            var flvRowMap = {};
+            flvRowMap[0x08] = 1;
+            flvRowMap[0x09] = 2;
+            flvRowMap[0x12] = 3;
+
+            // Drag state.
+            var dragStartX, dragStartY;
+            var isDrag = false;
+            var dragStartTime;
+            
+            var timeOffset = 0; // seconds back from live to show
 
             // Initiate buffer rendering.
             requestAnimationFrame(redrawBuffer);
 
-            function tag(time, type, debugStr)
+            function onCurrentTime(t, isAbsolute)
+            {
+                playheadTime = t;
+                
+                bufferDirty = true;
+            }
+
+            function onTag(time, type, debugStr)
             {
                 // Note tag.
                 tags.push({time: time, type: type});
                 
                 // Mark redraw needed.
                 bufferDirty = true;
+                lastTagSubmission = Date.now();
             }
             
             function adjustZoom(e)
@@ -93,20 +119,15 @@
                 var delta = -e.detail || e.wheelDelta;
                 
                 if(delta < 0)
-                    howFarBack = Math.max(1, howFarBack - 0.5);
+                    howFarBack = Math.max(howFarBack_min, howFarBack - howFarBack_step);
                 else
-                    howFarBack = Math.min(45, howFarBack + 0.5);
+                    howFarBack = Math.min(howFarBack_max, howFarBack + howFarBack_step);
                     
                 bufferDirty = true;
                 e.preventDefault();
                 return false;
             }
             
-            var dragStartX, dragStartY;
-            var isDrag = false;
-            var dragStartTime;
-            
-            var timeOffset = 0; // seconds back from live to show
             
             function onMouseDown(e)
             {
@@ -129,7 +150,7 @@
                 var localOffset = deltaX / secondsToPixels;
                 timeOffset = dragStartTime + localOffset;
                 timeOffset = Math.max(0, timeOffset);
-                timeOffset = Math.min(45, timeOffset);
+                timeOffset = Math.min(timeOffset_max, timeOffset);
                 
                 bufferDirty = true;
             }
@@ -143,6 +164,10 @@
             {
                 // Keep processing.
                 requestAnimationFrame(redrawBuffer);
+                
+                // Suppress if we've gotten new tags really recently.
+                if(Date.now() - lastTagSubmission < 64)
+                    return;
                 
                 // nop if no dirty.
                 if(bufferDirty == false)
@@ -201,16 +226,22 @@
                     ctx.fillStyle = wasBackwards ? "red" : "green";
                     ctx.fillRect(
                         width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
-                        tags[currentItemIdx].type * rowHeight, 1, rowHeight);
+                        flvRowMap[tags[currentItemIdx].type] * rowHeight, 1, rowHeight);
                     
                     currentItemIdx--;
                 }
                 
+                // Draw playhead.
+                ctx.fillStyle = "blue";
+                ctx.fillRect(
+                    width - (lastTimestamp - playheadTime) * secondsToPixels,
+                    0, 2, height);
+                
                 // Draw row headers.
                 ctx.fillStyle = "black";
-                ctx.fillText("Audio", 0, 8 * rowHeight);
-                ctx.fillText("Video", 0, 9 * rowHeight);
-                ctx.fillText("Script", 0, 0x12 * rowHeight);
+                ctx.fillText("Audio", 0, flvRowMap[8] * rowHeight);
+                ctx.fillText("Video", 0, flvRowMap[9] * rowHeight);
+                ctx.fillText("Script", 0, flvRowMap[0x12] * rowHeight);
             }
         </script>
     </head>
@@ -261,6 +292,6 @@
         </noscript>
         
         <!-- debug visualization -->
-        <canvas id="canvas" width="2048" height="1024"></canvas>     
+        <canvas id="canvas" width="1024" height="256"></canvas>     
    </body>
 </html>

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -400,6 +400,14 @@
                                 rowHeight * curManIndex * 2, 
                                 timeToPixel(curManItem.end) - timeToPixel(curManItem.start), 
                                 rowHeight * 2);
+                                
+                            ctx.lineStyle = "black";
+                            ctx.lineWidth = 2;
+                            ctx.strokeRect(
+                                timeToPixel(curManItem.start), 
+                                rowHeight * curManIndex * 2, 
+                                timeToPixel(curManItem.end) - timeToPixel(curManItem.start), 
+                                rowHeight * 2);
                         }
                         
                         ctx.fillStyle = "black";

--- a/TestPlayer/html-template/index.html
+++ b/TestPlayer/html-template/index.html
@@ -65,7 +65,7 @@
         
         <script>
             /***
-             * Debug interface.
+             * HLS OSMF plugin debug module.
              * 
              * Draggable timeline of converted samples.
              */
@@ -171,10 +171,10 @@
                 bufferDirty = true;
             }
             
-            function onTag(time, type, audioLow, videoLow, kept)
+            function onTag(time, type, audioLow, videoLow, kept, isKey)
             {
                 // Note tag.
-                tags.push({time: time, type: type, reject: !kept});
+                tags.push({time: time, type: type, reject: !kept, key: isKey});
 
                 // Update watermarks.
                 audioLowWatermark = audioLow / 1000;
@@ -310,7 +310,7 @@
                         ctx.fillStyle = tags[currentItemIdx].reject ? "red" : "green";
                         ctx.fillRect(
                             width - (lastTimestamp - tags[currentItemIdx].time) * secondsToPixels,
-                            flvRowMap[tags[currentItemIdx].type] * rowHeight, 1, rowHeight);
+                            flvRowMap[tags[currentItemIdx].type] * rowHeight, 1, tags[currentItemIdx].key ? rowHeight : rowHeight * 0.75);
                         
                         currentItemIdx--;
                     }

--- a/TestPlayer/src/TestPlayer.mxml
+++ b/TestPlayer/src/TestPlayer.mxml
@@ -12,6 +12,7 @@
 			import com.kaltura.hls.SubtitleTrait;
 			import com.kaltura.hls.SubtitleEvent;
 			import com.kaltura.hls.manifest.HLSManifestParser;
+			import com.kaltura.hls.HLSDVRTimeTrait;
 			
 			import mx.collections.ArrayList;
 			import mx.collections.IList;
@@ -22,6 +23,7 @@
 			import mx.managers.PopUpManager;
 			
 			import flash.net.FileReference;
+			import flash.external.ExternalInterface;
 
 			import org.osmf.net.httpstreaming.HLSHTTPNetStream;
 
@@ -43,6 +45,7 @@
 			import org.osmf.media.PluginInfoResource;
 			import org.osmf.media.URLResource;
 			import org.osmf.traits.DVRTrait;
+			import org.osmf.traits.TimeTrait;
 			import org.osmf.traits.MediaTraitType;
 			import org.osmf.traits.PlayState;
 			import org.osmf.utils.OSMFSettings;
@@ -358,7 +361,18 @@
 			
 			private function onTimeChange(event:TimeEvent):void {
 				currentTime = event.time;
-				
+
+				var tt:TimeTrait = element.getTrait(MediaTraitType.TIME) as TimeTrait;
+				if(!tt)
+					return;
+
+				// Great, time is knowable - so what is it?
+				var curTime:Number = tt.currentTime;
+				if(tt is HLSDVRTimeTrait)
+					curTime = (tt as HLSDVRTimeTrait).absoluteTime;
+
+				ExternalInterface.call("onCurrentTime(" + curTime + ", " + ((tt is HLSDVRTimeTrait) ? "true" : "false") + ")");
+
 				if (!scrubbing && !seeking) {
 					scrubber.value = currentTime;
 				}


### PR DESCRIPTION
This seems to behave well in our testing.

We have seen some issues where it appears to seek too far into a stream when starting a new video after playing another in the same session. However we have not been able to reproduce them reliably. This could be due to not clearing the low watermark flag properly. Please keep an eye out for this. I will look into this tomorrow and hopefully post a fix.

If you want to try the experimental I-frame filter, please comment out the part of the if clause on line 379 of M2TSFileHandler. This is not fully tested so is not included in this PR.

Debug visualizer logging is off by default. See README for details on how to turn it on.