### PR TITLE
Tweak threshold for customer stream.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -350,7 +350,7 @@ package com.kaltura.hls.m2ts
 		public static var flvLowWaterAudio:uint = 0;
 		public static var flvLowWaterVideo:uint = 0;
 		public static var flvRecoveringIFrame:Boolean = false;
-		public const filterThresholdMs:uint = 5;
+		public const filterThresholdMs:uint = 32;
 
 		private function clearFLVWaterMarkFilter():void
 		{


### PR DESCRIPTION
@itaykinnrot @einatr This works with basic testing. Let me know if I should do a full QA pass or if you want to try it. I believe the customer may have some out of order frames (perfectly valid) that confused the I-frame filter, thus the increased threshold.