### PR TITLE
Fix MP3 data passing.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/m2ts/FLVTranscoder.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/FLVTranscoder.as
@@ -469,7 +469,7 @@ package com.kaltura.hls.m2ts
             // TODO: determine MP3 PES Packet duration exactly.
             var duration:int = 16;
 
-            sendFLVTag(convertFLVTimestamp(pes.pts), FLVTags.TYPE_AUDIO, FLVTags.AUDIO_CODEC_MP3, -1, pes.buffer, 0, pes.buffer.length, duration);
+            sendFLVTag(convertFLVTimestamp(pes.pts), FLVTags.TYPE_AUDIO, FLVTags.AUDIO_CODEC_MP3, -1, pes.buffer, pes.headerLength, pes.buffer.length - pes.headerLength, duration);
         }
 
         private function generateScriptData(values:Array):ByteArray


### PR DESCRIPTION
This now allows playing MP3 audio tracks properly again. In addition, it has been tested with mixed MP3/AAC video (ie, different formats in different bitrates) and playback works properly.