### PR TITLE
More seeking/timewrap fixes.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
@@ -878,6 +878,30 @@ package com.kaltura.hls
 			return lastQuality;
 		}
 
+		public function get windowDuration():Number
+		{
+			var curManifest:HLSManifestParser = getManifestForQuality(lastQuality);
+			var segments:Vector.<HLSManifestSegment> = curManifest.segments;
+			if (segments.length == 0) 
+			{
+				trace("Failed to get windowDuration, no segments!");
+				return 0.0;
+			}
+
+			updateSegmentTimes(segments);
+
+			var firstSegment:HLSManifestSegment = segments[0];
+			var lastSegment:HLSManifestSegment  = segments[segments.length - 1];
+
+			return (lastSegment.startTime + lastSegment.duration) - firstSegment.startTime;
+		}
+
+		public function get isLiveEdgeValid():Boolean
+		{
+			var seg:Vector.<HLSManifestSegment> = getSegmentsForQuality(lastQuality);
+			return checkAnySegmentKnowledge(seg);
+		}
+
 		public function get liveEdge():Number
 		{
 			trace("Getting live edge using lastQuality=" + lastQuality);
@@ -993,7 +1017,7 @@ package com.kaltura.hls
 
 			if(seq == -1 && segments.length >= 2)
 			{
-				trace("getFileForTime - Got out of bound timestamp. Trying to recover...");
+				trace("getFileForTime - Got out of bound timestamp " + time + ". Trying to recover...");
 
 				var lastSeg:HLSManifestSegment = segments[Math.max(0, segments.length - (HLSManifestParser.MAX_SEG_BUFFER+1))];
 

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
@@ -206,7 +206,7 @@ package org.osmf.net.httpstreaming
 			
 			// Initialize ourselves.
 			_mainTimer.start();
-			_initialTime = -1;
+			_initialTime = 0;
 			_seekTime = -1;
 			_isPlaying = true;
 			_isPaused = false;
@@ -283,41 +283,31 @@ package org.osmf.net.httpstreaming
 		 */
 		override public function seek(offset:Number):void
 		{
-			if(offset < 0)
+			/*if(offset < 0)
 			{
 				offset = 0;	// FMS rule. Seek to <0 is same as seeking to zero.
-			}			
-
-			// Make sure we don't go past the buffer for the live edge.
-			if(indexHandler && offset > (indexHandler as HLSIndexHandler).liveEdge)
-			{
-				CONFIG::LOGGING
-				{
-					logger.info("Capping seek to the known-safe live edge (" + offset + " < " + (indexHandler as HLSIndexHandler).liveEdge + ").");
-				}
-				offset = (indexHandler as HLSIndexHandler).liveEdge;
-			}
+			}*/			
 
 			// we can't seek before the playback starts or if it has stopped.
 			if (_state != HTTPStreamingState.INIT)
 			{
-				if(_initialTime < 0)
+				_seekTarget = offset;
+
+				CONFIG::LOGGING
 				{
-					CONFIG::LOGGING
-					{
-						logger.info("Setting seek (A) to " + offset);
-					}
-					_seekTarget = offset + 0;	// this covers the "don't know initial time" case, rare
-				}
-				else
-				{
-					CONFIG::LOGGING
-					{
-						logger.info("Setting seek (B) to " + offset);
-					}
-					_seekTarget = offset + _initialTime;
-				}
+					logger.info("Setting seek (B) to " + offset);
+				}				
 				
+				// Make sure we don't go past the buffer for the live edge.
+				if(indexHandler && _seekTarget > (indexHandler as HLSIndexHandler).liveEdge)
+				{
+					CONFIG::LOGGING
+					{
+						logger.info("Capping seek to the known-safe live edge (" + _seekTarget + " < " + (indexHandler as HLSIndexHandler).liveEdge + ").");
+					}
+					_seekTarget = (indexHandler as HLSIndexHandler).liveEdge;
+				}
+
 				setState(HTTPStreamingState.SEEK);
 				
 				dispatchEvent(
@@ -1921,11 +1911,11 @@ package org.osmf.net.httpstreaming
 			{
 				if (_initialTime < 0)
 				{
-					_initialTime = _dvrInfo != null ? _dvrInfo.startTime : currentTime;
+					_initialTime = _dvrInfo != null ? _dvrInfo.startTime : 0;
 				}
 				if (_seekTime < 0)
 				{
-					_seekTime = currentTime;
+					//_seekTime = currentTime;
 				}
 			}		
 			else // doing enhanced seek
@@ -1976,11 +1966,11 @@ package org.osmf.net.httpstreaming
 					_enhancedSeekTarget = -1;
 					if (_seekTime < 0)
 					{
-						_seekTime = currentTime;
+						//_seekTime = currentTime;
 					}
 					if(_initialTime < 0)
 					{
-						_initialTime = currentTime;
+						_initialTime = 0;
 					}
 					
 					if (_enhancedSeekTags != null && _enhancedSeekTags.length > 0)

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamDownloader.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamDownloader.as
@@ -182,6 +182,9 @@ package org.osmf.net.httpstreaming
 				startTimeoutMonitor(_timeoutInterval);
 				_urlStream.load(_request);
 			}
+
+			// Dispatch an event so any listeners can find out.
+			_dispatcher.dispatchEvent(new HTTPStreamingEvent("dispatcherStart", false, false, 0, null, "", request.url.toString(), 0, "", this));
 		}
 		
 		/**

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
@@ -275,25 +275,6 @@ package org.osmf.net.httpstreaming
 			_didBeginSeek = false;
 			_didCompleteSeek = false;
 
-			if (_seekTarget < 0 )
-			{
-				if (_dvrInfo != null)
-				{
-					_seekTarget = Math.floor(_dvrInfo.startTime + _dvrInfo.curLength - OSMFSettings.hdsDVRLiveOffset);
-				}
-				else
-				{
-					if (_isLive)
-					{
-						_seekTarget = Math.floor(_offset);
-					}
-					else
-					{
-						_seekTarget = 0;
-					}
-				}
-			}
-
 			CONFIG::LOGGING
 			{			
 				logger.debug("Seeking to " + _seekTarget + " in stream [ " + loggedStreamName + " ]. ");


### PR DESCRIPTION
This fixes a major scenario where best effort fetches could be lost when seeking/changing bitrates, causing long stalls or failure to play back.

Seeking is now also more consistent - there were scenarios where it could introduce arbitrary offsets to the seek target time.

Note that the DVR window will be in whatever time range the stream is - so for instance ABC live right now is at -12 hours or something crazy like that. Your UI may need minor adjustments to behave properly when seeking to these times.