### PR TITLE
Fast Better Seeking

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/M2TSFileHandler.as
@@ -354,6 +354,14 @@ package com.kaltura.hls.m2ts
 				}
 				_parser.flush();
 			}
+
+			if(isBestEffort)
+			{
+				// Force processing immediately. We only need a starting timestamp.
+				trace("Extracting timestamps for BEF.");
+				_parser.handleBestEffortProcess();
+			}
+
 			_buffer = null;
 			buffer.position = 0;
 
@@ -364,6 +372,7 @@ package com.kaltura.hls.m2ts
 				{
 					logger.debug("Discarding normal data from best effort.");
 				}
+
 				buffer.length = 0;
 			}
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
@@ -301,6 +301,11 @@ package com.kaltura.hls.m2ts
             }
         }
 
+        public function handleBestEffortProcess():void
+        {
+            pesProcessor.processAllNalus();
+        }
+
         public function clear(clearAACConfig:Boolean = true):void
         {
             _streams = {};

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
@@ -959,6 +959,9 @@ package org.osmf.net.httpstreaming
 			// Feed buffer.
 			keepBufferFed();
 
+			// Make sure we are capped properly.
+			capSeekToLiveEdge();
+
 			// Check for seeking state.
 			if (seeking && time != timeBeforeSeek && _state != HTTPStreamingState.HALT)
 			{
@@ -1951,6 +1954,27 @@ package org.osmf.net.httpstreaming
 			return timestampCastHelper;
 		}
 
+		protected function capSeekToLiveEdge():void
+		{
+			// Make sure we don't go past the live edge even if it changes while seeking.
+			if(!indexHandler || !indexHandler.isLiveEdgeValid)
+				return;
+
+			var liveEdgeValue:Number = indexHandler.liveEdge;
+			//trace("Seeing live edge of " + liveEdgeValue);
+
+			if((_seekTarget < liveEdgeValue && _enhancedSeekTarget < liveEdgeValue) || isNaN(_enhancedSeekTarget))
+				return;
+
+			CONFIG::LOGGING
+			{
+				logger.warn("Capping seek (onTag) to the known-safe live edge (" + _seekTarget + " > " + liveEdgeValue + ", " + _enhancedSeekTarget + " > " + liveEdgeValue + ").");
+			}
+			_seekTarget = liveEdgeValue - 0.5;
+			_enhancedSeekTarget = liveEdgeValue - 0.5;
+			setState(HTTPStreamingState.SEEK);
+		}
+
 		/**
 		 * @private
 		 * 
@@ -1959,23 +1983,7 @@ package org.osmf.net.httpstreaming
 		 */
 		private function onTag(tag:FLVTag):Boolean
 		{
-
-			// Make sure we don't go past the live edge even if it changes while seeking.
-			if(indexHandler && indexHandler.isLiveEdgeValid)
-			{
-				var liveEdgeValue:Number = indexHandler.liveEdge;
-				//trace("Seeing live edge of " + liveEdgeValue);
-				if(_seekTarget > liveEdgeValue || _enhancedSeekTarget > liveEdgeValue)
-				{
-					CONFIG::LOGGING
-					{
-						logger.warn("Capping seek (onTag) to the known-safe live edge (" + _seekTarget + " > " + liveEdgeValue + ", " + _enhancedSeekTarget + " > " + liveEdgeValue + ").");
-					}
-					_seekTarget = liveEdgeValue - 0.5;
-					_enhancedSeekTarget = liveEdgeValue - 0.5;
-					setState(HTTPStreamingState.SEEK);
-				}
-			}
+			capSeekToLiveEdge();
 
 			if(_enhancedSeekTarget == Number.MAX_VALUE)
 			{

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamDownloader.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamDownloader.as
@@ -445,12 +445,12 @@ package org.osmf.net.httpstreaming
 					stopTimeoutMonitor();
 				}
 				_currentRetry = 0;
-				
-				_downloadBytesCount = event.bytesTotal;
-				CONFIG::LOGGING
-				{
-					logger.debug("Loaded " + event.bytesLoaded + " bytes from " + _downloadBytesCount + " bytes.");
-				}
+			}
+
+			_downloadBytesCount = event.bytesTotal;
+			CONFIG::LOGGING
+			{
+				logger.debug("Loaded " + event.bytesLoaded + " bytes from " + _downloadBytesCount + " bytes.");
 			}
 
 			_hasData = true;			

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
@@ -257,16 +257,6 @@ package org.osmf.net.httpstreaming
 		 */
 		public function seek(offset:Number):void
 		{
-			// Make sure we don't go past the buffer for the live edge.
-			/*if(_indexHandler && offset > (_indexHandler as HLSIndexHandler).liveEdge)
-			{
-				CONFIG::LOGGING 
-				{
-					logger.info("Capping seek (source) to the known-safe live edge (" + offset + " < " + (_indexHandler as HLSIndexHandler).liveEdge + ").");
-				}
-				offset = (_indexHandler as HLSIndexHandler).liveEdge;
-			}*/
-
 			_endOfStream = false;
 			_hasErrors = false;
 			_isLiveStalled = false;


### PR DESCRIPTION
Best effort fetches now terminate after ~500kb to help start streams
faster.
Live edge only considered valid if the stream doesn’t end.
More robust live edge determination.
Removed some dead code.
Live edge now capped more aggressively to avoid mis-seeks.