### PR TITLE
Assorted time, seek, and performance fixes.

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
@@ -185,7 +185,7 @@ package com.kaltura.hls
 		 * streams that overflow the MPEG TS timestamps. Very long windows (>27 hours) may not work
 		 * properly.
 		 */
-		public function updateSegmentTimes(segments:Vector.<HLSManifestSegment>, referenceTime:Number = 0):Vector.<HLSManifestSegment>
+		public function updateSegmentTimes(segments:Vector.<HLSManifestSegment>, referenceTime:Number = NaN):Vector.<HLSManifestSegment>
 		{
 			// Keep track of whatever segments we've assigned to.
 			var setSegments:Object = {};
@@ -199,11 +199,14 @@ package com.kaltura.hls
 				if(!startTimeWitnesses.hasOwnProperty(curUri))
 					continue;
 
-				//trace("Segment #" + i + " from start witness " + startTimeWitnesses[curUri]);
+				if(false) trace("Segment #" + i + " from start witness " + startTimeWitnesses[curUri]);
 				segments[i].startTime = startTimeWitnesses[curUri];
 
 				if(endTimeWitnesses.hasOwnProperty(curUri))
+				{
+					if(false) trace("Segment #" + i + " from end witness " + endTimeWitnesses[curUri]);
 					segments[i].duration = endTimeWitnesses[curUri] - segments[i].startTime;
+				}
 				
 				setSegments[i] = 1;
 			}
@@ -213,8 +216,12 @@ package com.kaltura.hls
 				// Then fill in any unknowns scanning forward....
 				for(i=1; i<segments.length; i++)
 				{
-					// Skip unknowns and explicitly set values.
-					if(!setSegments.hasOwnProperty(i-1) || setSegments.hasOwnProperty(i))
+					// We have an explicit value for this one, don't change it.
+					if(setSegments.hasOwnProperty(i))
+						continue;
+
+					// If the previous one isn't known, don't propagate it forward.
+					if(!setSegments.hasOwnProperty(i-1))
 						continue;
 
 					segments[i].startTime = segments[i-1].startTime + segments[i-1].duration;
@@ -224,8 +231,12 @@ package com.kaltura.hls
 				// And scanning back...
 				for(i=segments.length-2; i>=0; i--)
 				{
-					// Skip unknowns and explicitly set values.
-					if(!setSegments.hasOwnProperty(i+1) || setSegments.hasOwnProperty(i))
+					// We have an explicit value for this one, don't change it.
+					if(setSegments.hasOwnProperty(i))
+						continue;
+
+					// If the next one isn't known, don't propagate it back.
+					if(!setSegments.hasOwnProperty(i+1))
 						continue;
 
 					segments[i].startTime = segments[i+1].startTime - segments[i].duration;
@@ -240,12 +251,16 @@ package com.kaltura.hls
 			}
 
 			// Dump results:
-			/*trace("Last 10 manifest time reconstruction");
-			for(i=Math.max(0, segments.length - 100); i<segments.length; i++)
+			if(false)
 			{
-			trace("segment #" + i + " start=" + segments[i].startTime + " duration=" + segments[i].duration + "uri=" + segments[i].uri);
+				trace("Last 10 manifest time reconstruction");
+				for(i=Math.max(0, segments.length - 100); i<segments.length; i++)
+				{
+					trace("segment #" + i + " start=" + segments[i].startTime + " duration=" + segments[i].duration + "uri=" + segments[i].uri);
+				}
+				trace("Reconstructed manifest time with knowledge=" + checkAnySegmentKnowledge(segments) + " firstTime=" + (segments.length > 1 ? segments[0].startTime : -1) + " lastTime=" + (segments.length > 1 ? segments[segments.length-1].startTime : -1));
+
 			}
-			trace("Reconstructed manifest time with knowledge=" + checkAnySegmentKnowledge(segments) + " firstTime=" + (segments.length > 1 ? segments[0].startTime : -1) + " lastTime=" + (segments.length > 1 ? segments[segments.length-1].startTime : -1));*/
 			
 			// Done!
 			return segments;
@@ -925,12 +940,12 @@ package com.kaltura.hls
 			//trace("Getting live edge using targetQuality=" + targetQuality);
 
 			// Return time at least MAX_SEG_BUFFER from end of stream.
-			var seg:Vector.<HLSManifestSegment> = getSegmentsForQuality(lastQuality);
+			var seg:Vector.<HLSManifestSegment> = getSegmentsForQuality(targetQuality);
 			var backOff:Number = Math.min(HLSManifestParser.MAX_SEG_BUFFER + 1, seg.length - 1);
-			if(!seg || getManifestForQuality(lastQuality).streamEnds || backOff < 1)
+			if(!seg || getManifestForQuality(targetQuality).streamEnds || backOff < 1)
 				return Number.MAX_VALUE;
 			var lastSeg:HLSManifestSegment = seg[Math.max(0, seg.length - backOff)];
-			return lastSeg.startTime;
+			return lastSeg.startTime + 0.5; // Fudge to compensate for offset in capSeekToLiveEdge
 		}
 		
 		public override function getFileForTime(time:Number, quality:int):HTTPStreamRequest
@@ -1498,13 +1513,32 @@ package com.kaltura.hls
 		
 		private function getSegmentsForQuality( quality:int ):Vector.<HLSManifestSegment>
 		{
-			if ( !manifest ) return new Vector.<HLSManifestSegment>;
-			if ( manifest.streams.length < 1 || manifest.streams[0].manifest == null )
+			var result:Vector.<HLSManifestSegment> = null;
+
+			if ( !manifest )
 			{
-				return updateSegmentTimes(manifest.segments);
+				// No manifest found, return dummy.
+				result = new Vector.<HLSManifestSegment>();
 			}
-			else if ( quality >= manifest.streams.length ) return updateSegmentTimes(manifest.streams[0].manifest.segments);
-			else return updateSegmentTimes(manifest.streams[quality].manifest.segments);
+			else if ( manifest.streams.length < 1 || manifest.streams[0].manifest == null )
+			{
+				// No substreams, just return the main list.
+				result = manifest.segments;
+			}
+			else if ( quality >= manifest.streams.length ) 
+			{
+				// Invalid quality, return substream 0.
+				trace("getSegmentsForQuality - Got invalid quality level "  + quality + " returning level 0.");
+				result = manifest.streams[0].manifest.segments;
+			}
+			else
+			{
+				// Return the desired stream.
+				result = manifest.streams[quality].manifest.segments;
+			}
+
+			// Always update the segment times.
+			return updateSegmentTimes(result);
 		}
 		
 		private function getManifestForQuality( quality:int):HLSManifestParser
@@ -1813,16 +1847,18 @@ package com.kaltura.hls
 		 */
 		private function onBestEffortDownloadComplete(event:HTTPStreamingEvent):void
 		{
+			var downloader:HLSHTTPStreamDownloader = event.downloader as HLSHTTPStreamDownloader;
+
 			if(_bestEffortDownloaderMonitor == null ||
 				_bestEffortDownloaderMonitor != event.target as IEventDispatcher)
 			{
 				// we're receiving an event for a download we abandoned
-				trace("Got event for abandoned best effort download!");
+				trace("Got event for abandoned best effort download! Attempting to close downloader.");
+				if(downloader) downloader.close();
 				return;
 			}
 
 			// If we have 512kb of the segment and it's a progress event, we can probably get a timestamp.
-			var downloader:HLSHTTPStreamDownloader = event.downloader as HLSHTTPStreamDownloader;
 			if(downloader.totalAvailableBytes < 512*1024 && downloader.isComplete == false && event.type == HTTPStreamingEvent.DOWNLOAD_PROGRESS)
 				return;
 			

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/PESProcessor.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/PESProcessor.as
@@ -41,7 +41,7 @@ package com.kaltura.hls.m2ts
         protected var pendingBuffers:Vector.<Object> = new Vector.<Object>();
         protected var pendingLastConvertedIndex:int = 0;
 
-        public var lastPTS:Number = 0, lastDTS:Number = 0;
+        public var lastPTS:Number = NaN, lastDTS:Number = NaN;
 
         /**
          * Given a MPEG timestamp we've seen previously, determine if the new timestamp
@@ -74,7 +74,7 @@ package com.kaltura.hls.m2ts
             transcoder.clear(clearAACConfig);
 
             // Reset PTS/DTS reference.
-            lastPTS = lastDTS = 0;
+            lastPTS = lastDTS = NaN;
         }
 
         private function parseProgramAssociationTable(bytes:ByteArray, cursor:uint):Boolean

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -53,7 +53,7 @@ package com.kaltura.hls.manifest
 		 * until 10 seconds have passed and another segment becomes available.
 		 * Please take this into account when setting these values.
 		 */
-		public static var MAX_SEG_BUFFER:int = 4;
+		public static var MAX_SEG_BUFFER:int = 2;
 
 		/**
 		 * This overrides the value of the EXT-X-TARGETDURATION from any manifest we encounter.


### PR DESCRIPTION
Live edge changed to 2 segments not 4.
Fix for crash with null index handler.
Fixed issue with incorrect time reporting for five seconds after seek.
Fixed issue where calculating live edge would make seeks extremely slow.
Fixed issue where seeks would always be to end of segment before live
edge, not beginning of segment containing live edge.
Fixed issue where tag slightly out of order at start of some streams
caused corrupt playback.
Fixed time wrap issue in PES Processor and HLS index handler causing
incorrect timing as it tried to use 0 as a reference value when NaN
reference value was more inappropriate.
Get live edge from target quality to appropriately handle bitrate
changes.
More aggressively close best effort fetches.
Refactored getSegmentsForQuality for legibility.