### PR TITLE
Implements smart cancel logic

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSLoader.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSLoader.as
@@ -156,26 +156,37 @@ package com.kaltura.hls
 
 			var preferredIndex:int;
 
-			//If there is only one stream quality (or less) sets default to first stream
+			// If there is only one stream quality (or less) sets default to first stream
 			if (items.length <= 1)
 			{
 				preferredIndex = 0;
 			}
 			else if (HLSManifestParser.PREF_BITRATE != -1)
 			{
-				//If there is a preferred bitrate set by kaltura, tests all streams to find highest bitrate below the preferred
+				// If there is a preferred bitrate set by kaltura, tests all streams to find highest bitrate below the preferred
 				preferredIndex = 0;
-				var preferredDistance:Number = Number.MAX_VALUE;
+				var preferredDistance:int = int.MAX_VALUE;
 
 				for(var k:int=0; k<items.length; k++)
 				{
-					var curItem:DynamicStreamingItem = items[k];
-					var curDist:Number = Math.abs(items[k].bitrate - HLSManifestParser.PREF_BITRATE);
+					var curDist:int = Math.round(Math.abs(items[k].bitrate - HLSManifestParser.PREF_BITRATE));
 
-					/// Reject too low or not improved items.
-					if(curDist < 0 || curDist >= preferredDistance)
+					if(curDist > preferredDistance)
+					{
+						/// Reject too low or not improved items.
 						continue;
+					}
+					else if (curDist == preferredDistance)
+					{
+						// If we have two bitrates the same distance from preferred, check them
+						if (items[k].bitrate < items[preferredIndex].bitrate)
+						{
+							// If the current item bitrate is less than the preferredIndex, keep preferredIndex
+							continue;
+						}
+					}
 
+					// If all checks fail and the current item is superior, make the current item the preferredIndex.
 					preferredIndex = k;
 					preferredDistance = curDist;
 				}

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -130,6 +130,11 @@ package com.kaltura.hls.manifest
 		public static var MAX_BITRATE:int = -1;
 		public static var PREF_BITRATE:int = -1;
 
+		/**
+		 * Multiplier used to determine the segment timeout timer
+		 * -1 is off, default is 2 for 2x targetSegmentDuration
+		 */
+		public static var SEGMENT_TIMEOUT_MULTIPLIER:Number = 2;
 
 		public var type:String = DEFAULT;
 		public var version:int;

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPStreamSource.as
@@ -40,6 +40,7 @@ package org.osmf.net.httpstreaming
 
 	import com.kaltura.hls.HLSIndexHandler;
 	import com.kaltura.hls.m2ts.M2TSFileHandler;
+	import com.kaltura.hls.manifest.HLSManifestParser;
 	import flash.external.ExternalInterface;
 	
 	CONFIG::LOGGING
@@ -158,6 +159,18 @@ package org.osmf.net.httpstreaming
 			}
 			return false;
 		}
+
+		/**
+		 * Triggered by the SEGMENT_TIMEOUT event - forces the quality level to index 0
+ 		 */
+		public function forceDowngradeStreamQuality(event:Event):void
+ 		{
+			trace("SEGMENT_TIMEOUT event triggered the downgradeStreamQuality method");
+			var indexHandler:HLSIndexHandler = _indexHandler as HLSIndexHandler;
+			changeQualityLevel(indexHandler.getQualityLevelStreamName(0));
+			setState(HTTPStreamingState.LOAD);
+			doSomeProcessingAndGetBytes();
+ 		}
 
 		/**
 		 * @inheritDoc
@@ -490,7 +503,37 @@ package org.osmf.net.httpstreaming
 							{			
 								logger.debug("downloader.open "+_request.url);
 							}
-							_downloader.open(_request.urlRequest, downloaderMonitor, OSMFSettings.hdsFragmentDownloadTimeout);
+
+							if (HLSManifestParser.SEGMENT_TIMEOUT_MULTIPLIER != -1)
+							{
+								// If there is a multiplier set, passes in segment timeout data
+								// Casts the _indexHandler to an HLSIndexHandler to get target segment duration
+								var hlsIndexHandler:HLSIndexHandler = _indexHandler as HLSIndexHandler;
+								var targetSegmentDuration:Number;
+								if (hlsIndexHandler)
+								{
+									targetSegmentDuration = hlsIndexHandler.getTargetSegmentDuration();
+								}
+								else
+								{
+									targetSegmentDuration = -1;
+								}
+								// Adds the event listener to the downloaderMonitor that will be passed into the downloader 
+								// This occurs here because it may be one of two dispatchers
+								downloaderMonitor.addEventListener(HLSHTTPStreamDownloader.SEGMENT_TIMEOUT, forceDowngradeStreamQuality);
+								_downloader.openWithSegmentTimeout(_request.urlRequest, 
+																   downloaderMonitor, 
+																   OSMFSettings.hdsFragmentDownloadTimeout, 
+																   targetSegmentDuration);
+							}
+							else
+							{
+								// If the multiplier is disabled (-1), does not pass in segment timeout data
+								_downloader.open(_request.urlRequest, 
+												 downloaderMonitor, 
+												 OSMFSettings.hdsFragmentDownloadTimeout);
+							}
+
 							setState(HTTPStreamingState.BEGIN_FRAGMENT);
 							break;
 						case HTTPStreamRequestKind.RETRY:


### PR DESCRIPTION
Now the downloader monitors segment downloads and cancels them
when they take too long to switch to quality index zero immediately.
By default, too long is defined as 2x targetSegmentDuration.

Updates preferred bitrate logic to pick absolute closest bitrate
accurately
instead of picking closest above preferred.