### PR TITLE
Adds minimum buffer threshold logic to cap live streams

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -87,11 +87,22 @@ package com.kaltura.hls.manifest
 
 		/**
 		 * After we have stalled once, we switch to using this as the minimum 
-		 * buffer period to allow playback.
+		 * buffer period to allow playback. Only used for VOD's
 		 *
 		 * Playback will not begin until at least this much data is buffered.
 		 */
 		public static var NORMAL_BUFFER_THRESHOLD:Number = 21.0;
+
+		/**
+		 * This multiplier is used to hard limit the buffer threshold for live
+		 * streams - the threshold is calculated by the segment target duration
+		 * multiplied by this multiplier. 
+		 *
+		 * This keeps a live stream player from getting too out-of-sync with 
+		 * a live stream to the point where the segments are no longer in
+		 * the server cache.
+		 */
+		public static var LIVE_STREAM_BUFFER_THRESHOLD_MULTIPLIER:Number = 3.0;
 		
 		/**
 		 * How many seconds of video data should we keep in the buffer before 

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -100,8 +100,8 @@ package com.kaltura.hls.manifest
 		 * multiplied by this multiplier. 
 		 *
 		 * This keeps a live stream player from getting too out-of-sync with 
-		 * a live stream to the point where the segments are no longer in
-		 * the server cache.
+		 * a live stream to the point where the segments are no longer available
+		 * from the server.
 		 */
 		public static var LIVE_STREAM_BUFFER_THRESHOLD_MULTIPLIER:Number = 3.0;
 		

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -87,7 +87,8 @@ package com.kaltura.hls.manifest
 
 		/**
 		 * After we have stalled once, we switch to using this as the minimum 
-		 * buffer period to allow playback. Only used for VOD's
+		 * buffer period to allow playback. Only used for VODs. Live streams 
+		 * have other logic (see LIVE_STREAM_BUFFER_THRESHOLD_MULTIPLIER).
 		 *
 		 * Playback will not begin until at least this much data is buffered.
 		 */

--- a/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
+++ b/HLSPlugin/src/org/osmf/net/httpstreaming/HLSHTTPNetStream.as
@@ -428,8 +428,28 @@ package org.osmf.net.httpstreaming
 			if(neverBuffered)
 				return HLSManifestParser.INITIAL_BUFFER_THRESHOLD;
 
-			// Ok - in normal buffering. Calculate initial value.
-			return HLSManifestParser.NORMAL_BUFFER_THRESHOLD + bufferBias;
+			if ((indexHandler as HLSIndexHandler).isLive == false)
+			{
+				//Ok - in normal buffering. Calculate initial value.
+				return HLSManifestParser.NORMAL_BUFFER_THRESHOLD + bufferBias;
+			}
+			else
+			{
+				// Get the buffer threshold with buffer bias
+				var tempBufferBias:Number = HLSManifestParser.NORMAL_BUFFER_THRESHOLD + bufferBias;
+				// Get the maximum value allowed for a live stream
+				var tempBufferThreshold:Number = indexHandler.getTargetSegmentDuration() * HLSManifestParser.LIVE_STREAM_BUFFER_THRESHOLD_MULTIPLIER;
+
+				// Return the tempBufferBias if it is below the maximum value allowed
+				if (tempBufferBias < tempBufferThreshold)
+				{
+					return tempBufferBias;
+				}
+				else
+				{
+					return tempBufferThreshold;
+				}
+			}
 		}
 
 		/**


### PR DESCRIPTION
Adds minimum buffer threshold logic to cap live streams to keep it from blowing out of proportion with several buffering events - helps prevent getting too far out of sync with live stream