### PR TITLE
Manifest reloading delay logic improvement

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
+++ b/HLSPlugin/src/com/kaltura/hls/HLSIndexHandler.as
@@ -1602,9 +1602,9 @@ package com.kaltura.hls
 			
 			if ( (reloadingManifest || !manifest.streamEnds) && segments.length > 0)
 			{
-				trace("Stalling -- requested segment " + newSequence + " past the end " + segments[segments.length-1].id + " and we're in a live stream");
+				trace("Stalling -- requested segment " + newSequence + " past the end " + segments[segments.length-1].id + " and we're in a live stream - stalling for: " + (getManifestForQuality(origQuality).targetDuration/2) + " ms");
 				
-				return new HTTPStreamRequest(HTTPStreamRequestKind.LIVE_STALL, null, segments[segments.length-1].duration / 2);
+				return new HTTPStreamRequest(HTTPStreamRequestKind.LIVE_STALL, null, getManifestForQuality(origQuality).targetDuration/2);
 			}
 			
 			trace("Ending stream playback");

--- a/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/manifest/HLSManifestParser.as
@@ -144,6 +144,18 @@ package com.kaltura.hls.manifest
 		public static var BACKUP_MANIFEST_TIMEOUT:Number = 30;
 		public static var LIVE_STREAM_EMERGENCY_STALL_TIMEOUT:Number = 5;
 
+		/**
+		 * Toggles between using the target segment duration or using
+		 * the previous segment length to determine how long to wait
+		 * once an identical manifest has been reloaded. Default is 
+		 * false (target segment duration). True toggles to last segment length.
+		 * 
+		 * In live streams where the segments are regularly notably shorter than 
+		 * the target segment duration, it may be beneficial to toggle this to true.
+		 * Buffering issues have been observed in the case where it has to wait
+		 * too long to reload the manifest relative to the actual segment length. 
+		 */
+		public static var LIVE_STREAM_MINIMUM_MANIFEST_RELOAD:Boolean = false;
 
 		public var type:String = DEFAULT;
 		public var version:int;


### PR DESCRIPTION
Adds smart logic to manage the minimum manifest reloading delay for live streams. 

Allows toggling of a bool in HLSManifestParser, LIVE_STREAM_MINIMUM_MANIFEST_RELOAD to toggle between the minimum delay calculated as 1/2 target segment duration and 1/2 last segment length.

Fix is in relation to SUP-7612