### PR TITLE
Packet buffer flush fix

### DIFF
--- a/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
@@ -300,6 +300,8 @@ package com.kaltura.hls.m2ts
 
             pesProcessor.clear(true);
 
+            // Reset the buffer when we flush to remove any leftover packet parts
+            // Sometimes the wrong data here can cause an error processing the next segment
             _buffer.length = 0;
             _buffer.position = 0;
 

--- a/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
+++ b/HLSPlugin/src/com/kaltura/hls/m2ts/TSPacketParser.as
@@ -300,6 +300,9 @@ package com.kaltura.hls.m2ts
 
             pesProcessor.clear(true);
 
+            _buffer.length = 0;
+            _buffer.position = 0;
+
             CONFIG::LOGGING
             {
                 logger.debug("FLUSHING COMPLETE");


### PR DESCRIPTION
Adds code to reset the buffer when the TSPacketParser is told to flush. Bug found where sometimes a partial packet leftover during seeking could cause it to mis-process a packet and lead to image corruption.